### PR TITLE
Log the stderr output and the err

### DIFF
--- a/lib/git-process.ts
+++ b/lib/git-process.ts
@@ -101,6 +101,9 @@ export class GitProcess {
         }
 
         if ((err as any).code) {
+          console.error(stdErr)
+          console.error(err)
+
           // TODO: handle more error codes
           const code: number = (err as any).code
           if (code === gitNotFoundErrorCode) {


### PR DESCRIPTION
This shouldn’t be permanent, but it’s helpful for now in figuring out what happened when a command fails.
