### PR TITLE
Custom env

### DIFF
--- a/lib/git-process.ts
+++ b/lib/git-process.ts
@@ -67,14 +67,14 @@ export class GitProcess {
   /**
    *  Execute a command using the embedded Git environment
    */
-  public static exec(args: string[], path: string, input?: string, processCb?: (process: cp.ChildProcess) => void): Promise<void> {
-    return GitProcess.execWithOutput(args, path, input, processCb)
+  public static exec(args: string[], path: string, customEnv?: Object, processCb?: (process: cp.ChildProcess) => void): Promise<void> {
+    return GitProcess.execWithOutput(args, path, customEnv, processCb)
   }
 
   /**
    *  Execute a command and read the output using the embedded Git environment
    */
-  public static execWithOutput(args: string[], path: string, input?: string, processCb?: (process: cp.ChildProcess) => void): Promise<string> {
+  public static execWithOutput(args: string[], path: string, customEnv?: Object, processCb?: (process: cp.ChildProcess) => void): Promise<string> {
     return new Promise<string>(function(resolve, reject) {
       const gitLocation = GitProcess.resolveGitBinary()
       const startTime = performance.now()
@@ -91,7 +91,7 @@ export class GitProcess {
       }
       const env = Object.assign({}, process.env, {
         GIT_EXEC_PATH: GitProcess.resolveGitExecPath(),
-      })
+      }, customEnv)
 
       const spawnedProcess = cp.execFile(gitLocation, args, { cwd: path, encoding: 'utf8', env }, function(err, output, stdErr) {
         if (!err) {
@@ -132,11 +132,6 @@ export class GitProcess {
         console.error(err)
         reject(err)
       })
-
-      if (input !== undefined) {
-        spawnedProcess.stdin.write(input)
-        spawnedProcess.stdin.end()
-      }
 
       if (processCb) {
         processCb(spawnedProcess)


### PR DESCRIPTION
Let users pass in more environment variables.

More controversially, this also removes the `input`. I did this because it can be implemented by users using the `processCb`.
