### PR TITLE
Set the TEST environment variable when running npm test

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "tslint lib/**/*.ts",
     "build": "npm run clean && npm run lint && tsc -p ./tsconfig.json",
     "prepublish": "npm run build",
-    "test": "TEST=1 mocha --require ts-node/register test/*.ts",
+    "test": "cross-env TEST=1 mocha --require ts-node/register test/*.ts",
     "postinstall": "node ./script/download-git.js"
   },
   "engines": {
@@ -45,6 +45,7 @@
     "@types/rimraf": "0.0.27",
     "chai": "^3.5.0",
     "chai-as-promised": "^5.3.0",
+    "cross-env": "^2.0.1",
     "mocha": "^3.0.2",
     "ts-node": "^1.3.0",
     "tslint": "^3.15.1",


### PR DESCRIPTION
So that the path to Git is set correctly when running `npm test`
