### PR TITLE
Fix execfile callback type signature

### DIFF
--- a/lib/git-process.ts
+++ b/lib/git-process.ts
@@ -123,6 +123,11 @@ export class GitProcess {
         }
       }
 
+      // Explicitly annotate opts since typescript is unable to infer the correct
+      // signature for execFile when options is passed as an opaque hash. The type
+      // definition for execFile currently infers based on the encoding parameter
+      // which could change between declaration time and being passed to execFile.
+      // See https://git.io/vixyQ
       const opts: ExecOptionsWithStringEncoding = {
         cwd: path,
         encoding: 'utf8',


### PR DESCRIPTION
See #24

Use the correct overload type definition by explicitly annotating the type of the options object.

cc @shiftkey @BinaryMuse 
