### PR TITLE
Pass options to functions

### DIFF
--- a/lib/git-process.ts
+++ b/lib/git-process.ts
@@ -16,6 +16,10 @@ export interface IGitResult {
   readonly exitCode: number
 }
 
+/**
+ * A set of configuration options that can be passed when
+ * executing a git command.
+ */
 export interface IGitExecutionOptions {
   /**
    * An optional collection of key-value pairs which will be


### PR DESCRIPTION
The call signature of exec and execWithOutput are crowded enough as it is and this allows us more flexibility in designing the API going forward.
