### PR TITLE
Add the process callback back in

### DIFF
--- a/lib/git-process.ts
+++ b/lib/git-process.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs'
 
 import { execFile, ExecOptionsWithStringEncoding } from 'child_process'
 import { GitError, GitErrorRegexes, NotFoundExitCode } from './errors'
+import { ChildProcess } from 'child_process'
 
 /** The result of shelling out to git. */
 export interface IGitResult {
@@ -40,6 +41,15 @@ export interface IGitExecutionOptions {
    * parameter is a string.
    */
   readonly stdinEncoding?: string
+
+  /**
+   * An optional callback which will be invoked with the child
+   * process instance after spawning the git process.
+   *
+   * Note that if the stdin parameter was specified the stdin
+   * stream will be closed by the time this callback fires.
+   */
+   readonly processCallback?: (process: ChildProcess) => void
 }
 
 export class GitProcess {
@@ -152,6 +162,10 @@ export class GitProcess {
       if (options && options.stdin) {
         // See https://github.com/nodejs/node/blob/7b5ffa46fe4d2868c1662694da06eb55ec744bde/test/parallel/test-stdin-pipe-large.js
         spawnedProcess.stdin.end(options.stdin, options.stdinEncoding)
+      }
+
+      if (options && options.processCallback) {
+        options.processCallback(spawnedProcess)
       }
     })
   }


### PR DESCRIPTION
Turns out we need it until we implement a proper streaming api. Document
the mutual exclusivity of stdin and process.stdin
