### PR TITLE
undefined exit code? actually it's a "maxBuffer exceeded" error

### DIFF
--- a/lib/git-process.ts
+++ b/lib/git-process.ts
@@ -165,9 +165,12 @@ export class GitProcess {
           return
         }
 
-        if (err) {
+        if (code === undefined && err) {
+          // Git has returned an output that couldn't fit in the specified buffer
+          // as we don't know how many bytes it requires, rethrow the error with
+          // details about what it was previously set to...
           if (err.message === 'stdout maxBuffer exceeded') {
-            reject(new Error('The output from the command could not fit into the allocated stdout buffer. Set options.maxBuffer to a larger value than the default (10MB).'))
+            reject(new Error(`The output from the command could not fit into the allocated stdout buffer. Set options.maxBuffer to a larger value than ${execOptions.maxBuffer} bytes`))
           }
         }
 

--- a/test/git-process-test.ts
+++ b/test/git-process-test.ts
@@ -3,7 +3,6 @@ const expect = chai.expect
 
 import * as path from 'path'
 import * as fs from 'fs'
-
 import * as crypto from 'crypto'
 
 import { GitProcess, GitError } from '../lib'


### PR DESCRIPTION
Encountered this while testing a really, really, ridiculously large diff:

 - [x] added tests for exit code handling to ensure things were fine
 - [x] added failing test to trigger `maxBuffer` error
 - [x] handle and rethrow error rather than returning `undefined` exit code
 - [x] added parameter to execution options to let callers change limit  