### PR TITLE
Bump request lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-kitchen-sink",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "Incorporate Git into your Electron application",
   "main": "./build/lib/index.js",
   "typings": "./build/lib/index.d.ts",


### PR DESCRIPTION
Bumping request in order to get rid of deprecation warning of `node-uuid` which has been superseeded by `uuid`