### PR TITLE
use more specific environment flag when testing

### DIFF
--- a/lib/git-process.ts
+++ b/lib/git-process.ts
@@ -66,7 +66,7 @@ export class GitProcess {
    *  Find the path to the embedded Git environment
    */
   private static resolveGitDir(): string {
-    if (process.env.TEST) {
+    if (process.env.TEST_WITH_LOCAL_GIT) {
       return path.join(__dirname, '..', 'git')
     } else {
       return path.join(__dirname, '..', '..', 'git')

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "pack": "npm run pack-win && npm run pack-mac && npm run pack-linux",
     "prepublish": "npm run build && npm run test",
     "test": "npm run test:fast && npm run test:slow",
-    "test:fast": "cross-env TEST=1 mocha --require ts-node/register test/fast/*.ts test/auth/*.ts",
-    "test:slow": "cross-env TEST=1 mocha -t 10000ms --require ts-node/register test/slow/*.ts test/auth/*.ts",
+    "test:fast": "cross-env TEST_WITH_LOCAL_GIT=1 mocha --require ts-node/register test/fast/*.ts test/auth/*.ts",
+    "test:slow": "cross-env TEST_WITH_LOCAL_GIT=1 mocha -t 10000ms --require ts-node/register test/slow/*.ts test/auth/*.ts",
     "postinstall": "node ./script/download-git.js"
   },
   "engines": {


### PR DESCRIPTION
In a side project consuming `git-kitchen-sink` I'd also set a `TEST=1` flag, not realising this was affecting how Git was resolved. Oops.

Let's use something more specific to ensure no-one else gets confused by this... 