### PR TITLE
drop enforcement of quotemark when linting due to typo

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -19,10 +19,6 @@
       true,
       "check-open-brace"
     ],
-    "quotemark": [
-      true,
-      "singe"
-    ],
     "semicolon": [
       false,
       "always"


### PR DESCRIPTION
`"singe"` isn't a valid value here, and correcting the typo means `errors.ts` requires a whole bunch of changing `"` to `'` and potentially breaking those regexes. So I'm not gonna.