### PR TITLE
Git LFS hotfix update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dugite",
-  "version": "1.27.0",
+  "version": "1.28.0",
   "description": "Elegant bindings for Git",
   "main": "./build/lib/index.js",
   "typings": "./build/lib/index.d.ts",

--- a/script/config.js
+++ b/script/config.js
@@ -12,14 +12,14 @@ function getConfig() {
   }
 
   if (process.platform === 'darwin') {
-    config.checksum = 'ecf249a78d622cc73fe1bcbc7376c9dc5d5ebe66f32e1a8a660559fc0ccbfeee'
-    config.source = 'https://github.com/desktop/dugite-native/releases/download/v2.12.2-rc3/dugite-native-v2.12.2-macOS-181.tar.gz'
+    config.checksum = '17d95150b6a370353f0ed97f205ab822ec739da54f6843e596493d099123a82f'
+    config.source = 'https://github.com/desktop/dugite-native/releases/download/v2.12.2-rc5/dugite-native-v2.12.2-macOS-186.tar.gz'
   } else if (process.platform === 'win32') {
-    config.checksum = '279ea2a33de2c006fcdb68aecedad6b180ff215b7dbc0f74f4938b99d43cf089'
-    config.source = 'https://github.com/desktop/dugite-native/releases/download/v2.12.2-rc3/dugite-native-v2.12.2-win32-181.tar.gz'
+    config.checksum = '9f231f6955d8208f21774d43d187e3ecf85267f9bd9a799594c3227d3e473de2'
+    config.source = 'https://github.com/desktop/dugite-native/releases/download/v2.12.2-rc5/dugite-native-v2.12.2-win32-186.tar.gz'
   } else if (process.platform === 'linux') {
-    config.checksum = '5287d81eb563e3d5c7a459bae98dfd4f5a8b8ee903960032720baf421e67b9f8'
-    config.source = 'https://github.com/desktop/dugite-native/releases/download/v2.12.2-rc3/dugite-native-v2.12.2-ubuntu-181.tar.gz'
+    config.checksum = '3258900c0019b48517ee4e9d0c5702474bb133da6ea0e5703f6b744679779efa'
+    config.source = 'https://github.com/desktop/dugite-native/releases/download/v2.12.2-rc5/dugite-native-v2.12.2-ubuntu-186.tar.gz'
   }
 
   // compute the filename from the download source

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -2,7 +2,7 @@ import { GitProcess, IGitResult } from '../lib'
 
 // NOTE: bump these versions to the latest stable releases
 export const gitVersion = '2.12.2'
-export const gitLfsVersion = '2.0.2'
+export const gitLfsVersion = '2.1.1'
 
 const temp = require('temp').track()
 


### PR DESCRIPTION
Consumes the hotfix from `dugite-native` for closing out a Git LFS issue - https://github.com/desktop/dugite-native/releases/tag/v2.12.2-rc5 - I was hoping to start testing v2.13.0 at some point but Priorities™.