### PR TITLE
Handle when Dugite is in an ASAR archive

### DIFF
--- a/lib/git-environment.ts
+++ b/lib/git-environment.ts
@@ -7,7 +7,8 @@ function resolveGitDir(): string {
   if (process.env.LOCAL_GIT_DIRECTORY) {
     return path.resolve(process.env.LOCAL_GIT_DIRECTORY)
   } else {
-    return path.join(__dirname, '..', '..', 'git')
+    return path.resolve(__dirname, '..', '..', 'git')
+      .replace(/[\\\/]app.asar[\\\/]/, 'app.asar.unpacked');
   }
 }
 


### PR DESCRIPTION
When Dugite is in an ASAR archive and the caller has correctly put Git into the unpacked section, we need to adjust the path since ASAR is Not A Thing to Git