### PR TITLE
strip out some unneeded resources when packaging

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -15,7 +15,7 @@ test
 
 # skip the other folders too
 /docs
-
+/examples
 
 # Git will be downloaded at install time, don't include in package
 git/
@@ -24,3 +24,10 @@ git/
 /build/examples
 /build/script
 /build/test
+
+# output is transpiled JS - no need for these
+tslint.json
+tsconfig.json
+
+# config files
+*.yml


### PR DESCRIPTION
If you consume `dugite` into a Typescript project it might try and recurse into your `node_modules` folder and spit out this error:

```
file: 'file:///c%3A/Users/shiftkey/Documents/GitHub/desktop/app/node_modules/dugite/tsconfig.json'
severity: 'Error'
message: 'No inputs were found in config file 'c:/Users/shiftkey/Documents/GitHub/desktop/app/node_modules/dugite/tsconfig.json'. Specified 'include' paths were '["lib/**/*.ts","script/**/*.ts","test/**/*.ts"]' and 'exclude' paths were '["node_modules","build"]'.'
at: '1,1'
source: 'ts'
```

This file isn't needed when packaging, so let's remove it (and some other noise).