### PR TITLE
update git and capture regression test

### DIFF
--- a/script/config.js
+++ b/script/config.js
@@ -18,7 +18,7 @@ function getConfig() {
     config.checksum = '866aa1de21707d983427c9a8f4645169f966ab5d78f4d54de3b8b990cd83e35c'
     config.source = 'https://github.com/desktop/dugite-native/releases/download/v2.14.1-rc2/dugite-native-v2.14.1-win32-10.tar.gz'
   } else if (process.platform === 'linux') {
-    config.checksum = '866aa1de21707d983427c9a8f4645169f966ab5d78f4d54de3b8b990cd83e35c'
+    config.checksum = '534168503fc96a8981cb7eca6628b854bff54694ad7fc68a29018cc9d7110754'
     config.source = 'https://github.com/desktop/dugite-native/releases/download/v2.14.1-rc2/dugite-native-v2.14.1-ubuntu-10.tar.gz'
   }
 

--- a/script/config.js
+++ b/script/config.js
@@ -12,14 +12,14 @@ function getConfig() {
   }
 
   if (process.platform === 'darwin') {
-    config.checksum = '93c21455d41eb7d8ac0c3dd3113dab1748a7d4b228c70e06db98a5a75df247e1'
-    config.source = 'https://github.com/desktop/dugite-native/releases/download/v2.14.1-rc1/dugite-native-v2.14.1-macOS-7.tar.gz'
+    config.checksum = '700fc17972698c3b86c92df3ff35cff255da8192e98ef8c1bbe4252eacdb66c3'
+    config.source = 'https://github.com/desktop/dugite-native/releases/download/v2.14.1-rc2/dugite-native-v2.14.1-macOS-10.tar.gz'
   } else if (process.platform === 'win32') {
-    config.checksum = 'dd5d02570b537821dc2698bad3a44f79de4366be4f0ff2e80f35c681a670af89'
-    config.source = 'https://github.com/desktop/dugite-native/releases/download/v2.14.1-rc1/dugite-native-v2.14.1-win32-7.tar.gz'
+    config.checksum = '866aa1de21707d983427c9a8f4645169f966ab5d78f4d54de3b8b990cd83e35c'
+    config.source = 'https://github.com/desktop/dugite-native/releases/download/v2.14.1-rc2/dugite-native-v2.14.1-win32-10.tar.gz'
   } else if (process.platform === 'linux') {
-    config.checksum = '13b41ccefebbf909e07e1929c126bc24d17847d99c53d6ccff9267ad7c810ac1'
-    config.source = 'https://github.com/desktop/dugite-native/releases/download/v2.14.1-rc1/dugite-native-v2.14.1-ubuntu-7.tar.gz'
+    config.checksum = '866aa1de21707d983427c9a8f4645169f966ab5d78f4d54de3b8b990cd83e35c'
+    config.source = 'https://github.com/desktop/dugite-native/releases/download/v2.14.1-rc2/dugite-native-v2.14.1-ubuntu-10.tar.gz'
   }
 
   // compute the filename from the download source

--- a/test/fast/config-test.ts
+++ b/test/fast/config-test.ts
@@ -9,7 +9,7 @@ describe('config', () => {
   it('sets http.sslBackend on Windows', async () => {
     if (process.platform === 'win32') {
       const result = await GitProcess.exec([ 'config', '--system', 'http.sslBackend' ], os.homedir())
-      expect(result.stdout).to.equal('schannel')
+      expect(result.stdout.trim()).to.equal('schannel')
     }
   })
 })

--- a/test/fast/config-test.ts
+++ b/test/fast/config-test.ts
@@ -8,7 +8,7 @@ describe('config', () => {
 
   it('sets http.sslBackend on Windows', async () => {
     if (process.platform === 'win32') {
-      const result = await GitProcess.exec([ 'config', '--global', 'http.sslBackend' ], os.homedir())
+      const result = await GitProcess.exec([ 'config', '--system', 'http.sslBackend' ], os.homedir())
       expect(result.stdout).to.equal('schannel')
     }
   })

--- a/test/fast/config-test.ts
+++ b/test/fast/config-test.ts
@@ -1,0 +1,15 @@
+import * as chai from 'chai'
+const expect = chai.expect
+
+import { GitProcess } from '../../lib'
+import * as os from 'os'
+
+describe('config', () => {
+
+  it('sets http.sslBackend on Windows', async () => {
+    if (process.platform === 'win32') {
+      const result = await GitProcess.exec([ 'config', '--global', 'http.sslBackend' ], os.homedir())
+      expect(result.stdout).to.equal('schannel')
+    }
+  })
+})


### PR DESCRIPTION
Consuming https://github.com/desktop/dugite-native/pull/57 to get the `http.sslBackend` fix.