### PR TITLE
GH-113: Made sure that `GIT_EXEC_PATH` is used as is when configured.

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -6,7 +6,7 @@
     interact with Git
  - `IGitResult` - the abstraction for a result returned by Git - contains
     exit code and standard output/error text
- - `IGitExecutionOptions` - additional overrides to change the behaviour
+ - `IGitExecutionOptions` - additional overrides to change the behavior
     of `GitProcess` (see [API extensibility](./api-extensibility.md) for
     more information)
  - `GitError` - a collection of known error codes that `dugite` can understand

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -6,7 +6,7 @@
     interact with Git
  - `IGitResult` - the abstraction for a result returned by Git - contains
     exit code and standard output/error text
- - `IGitExecutionOptions` - additional overrides to change the behavior
+ - `IGitExecutionOptions` - additional overrides to change the behaviour
     of `GitProcess` (see [API extensibility](./api-extensibility.md) for
     more information)
  - `GitError` - a collection of known error codes that `dugite` can understand

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -12,4 +12,4 @@ To ensure everything is working, run this command from the root of the repositor
 npm install
 ```
 
-This will install the depedencies, compile the library source and run the suite of tests.
+This will install the dependencies, compile the library source and run the suite of tests.

--- a/lib/git-environment.ts
+++ b/lib/git-environment.ts
@@ -1,7 +1,10 @@
 import * as path from 'path'
 
 /**
- *  Find the path to the embedded Git environment
+ *  Find the path to the embedded Git environment.
+ *
+ *  If a custom Git directory path is defined as the `LOCAL_GIT_DIRECTORY` environment variable, then
+ *  returns with it after resolving it as a path.
  */
 function resolveGitDir(): string {
   if (process.env.LOCAL_GIT_DIRECTORY) {
@@ -14,7 +17,7 @@ function resolveGitDir(): string {
 }
 
 /**
- *  Find the path to the embedded Git binary
+ *  Find the path to the embedded Git binary.
  */
 function resolveGitBinary(): string {
   const gitDir = resolveGitDir()
@@ -29,16 +32,23 @@ function resolveGitBinary(): string {
 
 /**
  * Find the path to the embedded git exec path.
+ *
+ * If a custom git exec path is given as the `GIT_EXEC_PATH` environment variable,
+ * then it returns with it after resolving it as a path.
  */
 function resolveGitExecPath(): string {
-  const gitDir = resolveGitDir()
-  if (process.platform === 'darwin' || process.platform === 'linux') {
-    return path.join(gitDir, 'libexec', 'git-core')
-  } else if (process.platform === 'win32') {
-    return path.join(gitDir, 'mingw64', 'libexec', 'git-core')
-  }
+  if (process.env.GIT_EXEC_PATH) {
+    return path.resolve(process.env.GIT_EXEC_PATH)
+  } else {
+    const gitDir = resolveGitDir()
+    if (process.platform === 'darwin' || process.platform === 'linux') {
+      return path.join(gitDir, 'libexec', 'git-core')
+    } else if (process.platform === 'win32') {
+      return path.join(gitDir, 'mingw64', 'libexec', 'git-core')
+    }
 
-  throw new Error('Git not supported on platform: ' + process.platform)
+    throw new Error('Git not supported on platform: ' + process.platform)
+  }
 }
 
 /**
@@ -89,7 +99,7 @@ export function setupEnvironment(environmentVariables: Object): { env: Object, g
     env.PREFIX = gitDir
 
     // bypass whatever certificates might be set and use
-    // the bundle included in the distibution
+    // the bundle included in the distribution
     const sslCABundle = `${gitDir}/ssl/cacert.pem`
     env.GIT_SSL_CAINFO = sslCABundle
   }

--- a/lib/git-environment.ts
+++ b/lib/git-environment.ts
@@ -39,16 +39,15 @@ function resolveGitBinary(): string {
 function resolveGitExecPath(): string {
   if (process.env.GIT_EXEC_PATH) {
     return path.resolve(process.env.GIT_EXEC_PATH)
-  } else {
-    const gitDir = resolveGitDir()
-    if (process.platform === 'darwin' || process.platform === 'linux') {
-      return path.join(gitDir, 'libexec', 'git-core')
-    } else if (process.platform === 'win32') {
-      return path.join(gitDir, 'mingw64', 'libexec', 'git-core')
-    }
-
-    throw new Error('Git not supported on platform: ' + process.platform)
   }
+  const gitDir = resolveGitDir()
+  if (process.platform === 'darwin' || process.platform === 'linux') {
+    return path.join(gitDir, 'libexec', 'git-core')
+  } else if (process.platform === 'win32') {
+    return path.join(gitDir, 'mingw64', 'libexec', 'git-core')
+  }
+
+  throw new Error('Git not supported on platform: ' + process.platform)
 }
 
 /**

--- a/test/fast/environment-test.ts
+++ b/test/fast/environment-test.ts
@@ -20,19 +20,19 @@ describe('environment variables', () => {
   })
 
   it('when GIT_EXEC_PATH environment variable *not* is set, it will be calculated', async () => {
-    expect(process.env.GIT_EXEC_PATH).to.be.undefined;
-    const { env } = await setupEnvironment({});
-    expect((<any>env)['GIT_EXEC_PATH']).not.to.be.undefined;
+    expect(process.env.GIT_EXEC_PATH).to.be.undefined
+    const { env } = await setupEnvironment({})
+    expect((<any>env)['GIT_EXEC_PATH']).not.to.be.undefined
   })
 
   it('when GIT_EXEC_PATH environment variable is set, that will be used as is', async () => {
-    expect(process.env.GIT_EXEC_PATH).to.be.undefined;
+    expect(process.env.GIT_EXEC_PATH).to.be.undefined
     try {
-      process.env.GIT_EXEC_PATH = __filename;
-      const { env } = await setupEnvironment({});
+      process.env.GIT_EXEC_PATH = __filename
+      const { env } = await setupEnvironment({})
       expect((<any>env)['GIT_EXEC_PATH']).to.be.equal(__filename)
     } finally {
-      delete process.env.GIT_EXEC_PATH;
+      delete process.env.GIT_EXEC_PATH
     }
   })
 })

--- a/test/fast/environment-test.ts
+++ b/test/fast/environment-test.ts
@@ -2,6 +2,7 @@ import * as chai from 'chai'
 const expect = chai.expect
 
 import { GitProcess } from '../../lib'
+import { setupEnvironment } from '../../lib/git-environment'
 
 const temp = require('temp').track()
 
@@ -16,5 +17,22 @@ describe('environment variables', () => {
       }
     })
     expect(result.stdout).to.equal('Foo Bar <foo@bar.com> 1475703207 +0200\n')
+  })
+
+  it('when GIT_EXEC_PATH environment variable *not* is set, it will be calculated', async () => {
+    expect(process.env.GIT_EXEC_PATH).to.be.undefined;
+    const { env } = await setupEnvironment({});
+    expect((<any>env)['GIT_EXEC_PATH']).not.to.be.undefined;
+  })
+
+  it('when GIT_EXEC_PATH environment variable is set, that will be used as is', async () => {
+    expect(process.env.GIT_EXEC_PATH).to.be.undefined;
+    try {
+      process.env.GIT_EXEC_PATH = __filename;
+      const { env } = await setupEnvironment({});
+      expect((<any>env)['GIT_EXEC_PATH']).to.be.equal(__filename)
+    } finally {
+      delete process.env.GIT_EXEC_PATH;
+    }
   })
 })

--- a/test/fast/environment-test.ts
+++ b/test/fast/environment-test.ts
@@ -19,7 +19,7 @@ describe('environment variables', () => {
     expect(result.stdout).to.equal('Foo Bar <foo@bar.com> 1475703207 +0200\n')
   })
 
-  it('when GIT_EXEC_PATH environment variable *not* is set, it will be calculated', async () => {
+  it('when GIT_EXEC_PATH environment variable is *not* set, it will be calculated', async () => {
     expect(process.env.GIT_EXEC_PATH).to.be.undefined
     const { env } = await setupEnvironment({})
     expect((<any>env)['GIT_EXEC_PATH']).not.to.be.undefined


### PR DESCRIPTION
Task: #113.

Please let me know if I have to add more test cases to cover the changes. Thanks!

Signed-off-by: Akos Kitta <kittaakos@gmail.com>