### PR TITLE
Parse LFS value mismatch error

### DIFF
--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -29,6 +29,7 @@ export enum GitError {
   BadRevision,
   NotAGitRepository,
   CannotMergeUnrelatedHistories,
+  LFSAttributeDoesNotMatch,
   // GitHub-specific error codes
   PushWithFileSizeExceedingLimit,
   HexBranchNameRejected,
@@ -84,6 +85,7 @@ export const GitErrorRegexes = {
   'fatal: Not a git repository \\(or any of the parent directories\\): (.*)':
     GitError.NotAGitRepository,
   'fatal: refusing to merge unrelated histories': GitError.CannotMergeUnrelatedHistories,
+  'The .+ attribute should be .+ but is .+': GitError.LFSAttributeDoesNotMatch,
   // GitHub-specific errors
   'error: GH001: ': GitError.PushWithFileSizeExceedingLimit,
   'error: GH002: ': GitError.HexBranchNameRejected,

--- a/test/fast/git-process-test.ts
+++ b/test/fast/git-process-test.ts
@@ -198,5 +198,12 @@ remote: http://github.com/settings/emails`
       const error = GitProcess.parseError(stderr)
       expect(error).to.equal(GitError.PushWithPrivateEmail)
     })
+
+    it('can parse LFS attribute does not match error', () => {
+      const stderr = `The filter.lfs.clean attribute should be "git-lfs clean -- %f" but is "git lfs clean %f"`
+
+      const error = GitProcess.parseError(stderr)
+      expect(error).to.equal(GitError.LFSAttributeDoesNotMatch)
+    })
   })
 })


### PR DESCRIPTION
I tried to come up with a test where we actually check against the values from LFS, but I couldn't get it to work without modifying the global gitconfig, which is a bad time for running locally :hurtrealbad: 