### PR TITLE
GH-129: Skip external tests gracefully when executable is not found.

### DIFF
--- a/test/external/git-process-external-test.ts
+++ b/test/external/git-process-external-test.ts
@@ -12,7 +12,11 @@ describe('git-process [with external Git executable]', () => {
   let git: Git | undefined
 
   before(async () => {
-    git = await findGit()
+    try {
+      git = await findGit()
+    } catch (error) {
+      git = undefined
+    }
     if (!git || !git.path || !git.execPath) {
       git = undefined
     } else {

--- a/test/external/git-process-external-test.ts
+++ b/test/external/git-process-external-test.ts
@@ -9,13 +9,12 @@ import { verify } from '../helpers'
 const temp = require('temp').track()
 
 describe('git-process [with external Git executable]', () => {
-  let git: Git | undefined
+  let git: Git | undefined = undefined
 
   before(async () => {
     try {
       git = await findGit()
-    } catch (error) {
-      git = undefined
+    } catch {
     }
     if (!git || !git.path || !git.execPath) {
       git = undefined
@@ -27,7 +26,7 @@ describe('git-process [with external Git executable]', () => {
     }
   })
 
-  beforeEach(async function() {
+  beforeEach(async function () {
     if (!git) {
       console.warn(`External Git was not found on the host system.`)
       this.skip()
@@ -35,7 +34,7 @@ describe('git-process [with external Git executable]', () => {
   })
 
   describe('clone', () => {
-    it('returns exit code when successful', async function() {
+    it('returns exit code when successful', async () => {
       const testRepoPath = temp.mkdirSync('desktop-git-clone-valid-external')
       const result = await GitProcess.exec(
         ['clone', '--', 'https://github.com/TypeFox/find-git-exec.git', '.'],

--- a/test/external/git-process-external-test.ts
+++ b/test/external/git-process-external-test.ts
@@ -14,8 +14,7 @@ describe('git-process [with external Git executable]', () => {
   before(async () => {
     try {
       git = await findGit()
-    } catch {
-    }
+    } catch {}
     if (!git || !git.path || !git.execPath) {
       git = undefined
     } else {
@@ -26,7 +25,7 @@ describe('git-process [with external Git executable]', () => {
     }
   })
 
-  beforeEach(async function () {
+  beforeEach(async function() {
     if (!git) {
       console.warn(`External Git was not found on the host system.`)
       this.skip()


### PR DESCRIPTION
Previously, tests failed with an error.

Closes #129.

Signed-off-by: Akos Kitta <kittaakos@gmail.com>