### PR TITLE
tidy up some catch statements

### DIFF
--- a/lib/git-process.ts
+++ b/lib/git-process.ts
@@ -93,7 +93,7 @@ export class GitProcess {
     try {
       fs.accessSync(path, (fs as any).F_OK)
       return true
-    } catch (e) {
+    } catch {
       return false
     }
   }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,6 @@
     "prettier": "^1.6.1",
     "temp": "^0.8.3",
     "ts-node": "^3.0.2",
-    "typescript": "^2.3.2"
+    "typescript": "^2.5.2"
   }
 }

--- a/test/fast/git-process-test.ts
+++ b/test/fast/git-process-test.ts
@@ -85,7 +85,7 @@ describe('git-process', () => {
             ['diff', '--no-index', '--patch-with-raw', '-z', '--', '/dev/null', 'new-file.md'],
             testRepoPath
           )
-        } catch (e) {
+        } catch {
           throws = true
         }
         expect(throws).to.be.true

--- a/test/slow/node-shenanigans.ts
+++ b/test/slow/node-shenanigans.ts
@@ -10,7 +10,7 @@ describe('node shenanigans', () => {
 
     try {
       buffer.toString('utf-8')
-    } catch (err) {
+    } catch {
       // we expect this to happen
       done()
       return


### PR DESCRIPTION
TS 2.5 let's you define an empty `catch` statement for situations where you don't need to look at the error.