### PR TITLE
Bump to latest Git LFS

### DIFF
--- a/script/config.js
+++ b/script/config.js
@@ -12,14 +12,14 @@ function getConfig() {
   }
 
   if (process.platform === 'darwin') {
-    config.checksum = '8c2440b8990500b2ed4cc37f779cf17165052bd0ec2ca77be4161173fe56ac23'
-    config.source = 'https://github.com/desktop/dugite-native/releases/download/v2.14.2-rc1/dugite-native-v2.14.2-macOS-16.tar.gz'
+    config.checksum = 'd9f5afe8c0c18c9d595e57e1e96958a337a0ee72d547d3cbf0e698d69b524a1e'
+    config.source = 'https://github.com/desktop/dugite-native/releases/download/v2.14.2-rc3/dugite-native-v2.14.2-macOS-20.tar.gz'
   } else if (process.platform === 'win32') {
-    config.checksum = 'fb6228381a08b0acd037b8fdcdb367c6dc6257f1e62015fe5178c62e648783fe'
-    config.source = 'https://github.com/desktop/dugite-native/releases/download/v2.14.2-rc1/dugite-native-v2.14.2-win32-16.tar.gz'
+    config.checksum = 'bfe092195459ba9a1e88c8d0b6812373cdc01877ae7f9b2c05c8e463398f372c'
+    config.source = 'https://github.com/desktop/dugite-native/releases/download/v2.14.2-rc3/dugite-native-v2.14.2-win32-20.tar.gz'
   } else if (process.platform === 'linux') {
-    config.checksum = '9d7ff67091485c35382ecf294d01a2cfada0d98390f1b530753fa64c2c51df75'
-    config.source = 'https://github.com/desktop/dugite-native/releases/download/v2.14.2-rc1/dugite-native-v2.14.2-ubuntu-16.tar.gz'
+    config.checksum = 'aa8a9107b310b65cb26143e82fdbc1c48a4cc9efc63aeb64b33710ec3ceefb67'
+    config.source = 'https://github.com/desktop/dugite-native/releases/download/v2.14.2-rc3/dugite-native-v2.14.2-ubuntu-20.tar.gz'
   }
 
   // compute the filename from the download source

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -2,7 +2,7 @@ import { GitProcess, IGitResult } from '../lib'
 
 // NOTE: bump these versions to the latest stable releases
 export const gitVersion = '2.14.2'
-export const gitLfsVersion = '2.3.1'
+export const gitLfsVersion = '2.3.4'
 
 const temp = require('temp').track()
 


### PR DESCRIPTION
This upgrades us to Git LFS 2.3.4 which has some helpful bugfixes.