### PR TITLE
add path to sh.exe so hooks can be run on Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ cache:
     - node_modules
 
 install:
-  - npm install -g npm@5.4.2
-  - npm install
+  - npm install -g npm@5.5.1
+  - npm install --ignore-scripts
   - npm run build
   - npm run is-it-pretty
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ cache:
 
 install:
   - npm install -g npm@5.5.1
-  - npm install --ignore-scripts
+  - npm install
   - npm run build
   - npm run is-it-pretty
 

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+    "recommendations": [
+      "samverschueren.final-newline",
+      "DmitryDorofeev.empty-indent",
+      "esbenp.prettier-vscode"
+    ]
+  }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,8 @@
-// Place your settings in this file to overwrite default and user settings.
 {
   "files.exclude": {
     "**/.git": true,
     "**/.DS_Store": true,
     "build": true
-  }
+  },
+  "editor.formatOnSave": true
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,8 +22,8 @@ version: "{build}"
 
 install:
   - ps: Install-Product node $env:nodejs_version $env:platform
-  - npm install -g npm@5.4.2
-  - npm install
+  - npm install -g npm@5.5.1
+  - npm install --ignore-scripts
   - npm run is-it-pretty
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ version: "{build}"
 install:
   - ps: Install-Product node $env:nodejs_version $env:platform
   - npm install -g npm@5.5.1
-  - npm install --ignore-scripts
+  - npm install
   - npm run is-it-pretty
 
 build_script:

--- a/lib/git-environment.ts
+++ b/lib/git-environment.ts
@@ -72,7 +72,7 @@ export function setupEnvironment(
   const gitDir = resolveGitDir()
 
   if (process.platform === 'win32') {
-    envPath = `${gitDir}\\mingw64\\bin;${envPath}`
+    envPath = `${gitDir}\\mingw64\\bin;${gitDir}\\mingw64\\usr\\bin;${envPath}`
   }
 
   const env = Object.assign(

--- a/test/slow/git-process-test.ts
+++ b/test/slow/git-process-test.ts
@@ -146,20 +146,26 @@ describe('git-process', () => {
     describe('checkout', () => {
       it('runs hook without error', async () => {
         const testRepoPath = await initialize('desktop-git-checkout-hooks')
-        const postCheckoutScript =
-`
-#!/bin/bash
+        const readme = Path.join(testRepoPath, 'README.md')
 
-echo 'post-check out hook ran'
-`
+        Fs.writeFileSync(readme, '# README', { encoding: 'utf8' })
+
+        await GitProcess.exec(['add', '.'], testRepoPath)
+        await GitProcess.exec(['commit', '-m', '"added README"'], testRepoPath)
+
+        await GitProcess.exec(['checkout', '-b', 'some-other-branch'], testRepoPath)
+
+        const postCheckoutScript =
+`#!/bin/bash
+echo 'post-check out hook ran'`
         const postCheckoutFile = Path.join(testRepoPath, '.git', 'hooks', 'post-checkout')
 
-        Fs.writeFileSync(postCheckoutFile, postCheckoutScript, { encoding: 'utf8'})
+        Fs.writeFileSync(postCheckoutFile, postCheckoutScript, { encoding: 'utf8' })
 
-        const result = await GitProcess.exec(['checkout', '-b', 'some-other-branch'], testRepoPath)
+        const result = await GitProcess.exec(['checkout', 'master'], testRepoPath)
         verify(result, r => {
           expect(r.exitCode).to.equal(0)
-          expect(r.stdout).contains('post-check out hook ran')
+          expect(r.stderr).contains('post-check out hook ran')
         })
       })
     })

--- a/test/slow/git-process-test.ts
+++ b/test/slow/git-process-test.ts
@@ -156,7 +156,7 @@ describe('git-process', () => {
         await GitProcess.exec(['checkout', '-b', 'some-other-branch'], testRepoPath)
 
         const postCheckoutScript =
-`#!/bin/bash
+`#!/bin/sh
 echo 'post-check out hook ran'`
         const postCheckoutFile = Path.join(testRepoPath, '.git', 'hooks', 'post-checkout')
 

--- a/test/slow/git-process-test.ts
+++ b/test/slow/git-process-test.ts
@@ -154,8 +154,7 @@ describe('git-process', () => {
 
       await GitProcess.exec(['checkout', '-b', 'some-other-branch'], testRepoPath)
 
-      const postCheckoutScript =
-`#!/bin/sh
+      const postCheckoutScript = `#!/bin/sh
 echo 'post-check out hook ran'`
       const postCheckoutFile = Path.join(testRepoPath, '.git', 'hooks', 'post-checkout')
 
@@ -168,5 +167,4 @@ echo 'post-check out hook ran'`
       })
     })
   })
-
 })

--- a/test/slow/git-process-test.ts
+++ b/test/slow/git-process-test.ts
@@ -142,32 +142,31 @@ describe('git-process', () => {
     })
   })
 
-  if (process.platform === 'win32') {
-    describe('checkout', () => {
-      it('runs hook without error', async () => {
-        const testRepoPath = await initialize('desktop-git-checkout-hooks')
-        const readme = Path.join(testRepoPath, 'README.md')
+  describe('checkout', () => {
+    it('runs hook without error', async () => {
+      const testRepoPath = await initialize('desktop-git-checkout-hooks')
+      const readme = Path.join(testRepoPath, 'README.md')
 
-        Fs.writeFileSync(readme, '# README', { encoding: 'utf8' })
+      Fs.writeFileSync(readme, '# README', { encoding: 'utf8' })
 
-        await GitProcess.exec(['add', '.'], testRepoPath)
-        await GitProcess.exec(['commit', '-m', '"added README"'], testRepoPath)
+      await GitProcess.exec(['add', '.'], testRepoPath)
+      await GitProcess.exec(['commit', '-m', '"added README"'], testRepoPath)
 
-        await GitProcess.exec(['checkout', '-b', 'some-other-branch'], testRepoPath)
+      await GitProcess.exec(['checkout', '-b', 'some-other-branch'], testRepoPath)
 
-        const postCheckoutScript =
+      const postCheckoutScript =
 `#!/bin/sh
 echo 'post-check out hook ran'`
-        const postCheckoutFile = Path.join(testRepoPath, '.git', 'hooks', 'post-checkout')
+      const postCheckoutFile = Path.join(testRepoPath, '.git', 'hooks', 'post-checkout')
 
-        Fs.writeFileSync(postCheckoutFile, postCheckoutScript, { encoding: 'utf8' })
+      Fs.writeFileSync(postCheckoutFile, postCheckoutScript, { encoding: 'utf8' })
 
-        const result = await GitProcess.exec(['checkout', 'master'], testRepoPath)
-        verify(result, r => {
-          expect(r.exitCode).to.equal(0)
-          expect(r.stderr).contains('post-check out hook ran')
-        })
+      const result = await GitProcess.exec(['checkout', 'master'], testRepoPath)
+      verify(result, r => {
+        expect(r.exitCode).to.equal(0)
+        expect(r.stderr).contains('post-check out hook ran')
       })
     })
-  }
+  })
+
 })

--- a/test/slow/git-process-test.ts
+++ b/test/slow/git-process-test.ts
@@ -158,7 +158,7 @@ describe('git-process', () => {
 echo 'post-check out hook ran'`
       const postCheckoutFile = Path.join(testRepoPath, '.git', 'hooks', 'post-checkout')
 
-      Fs.writeFileSync(postCheckoutFile, postCheckoutScript, { encoding: 'utf8' })
+      Fs.writeFileSync(postCheckoutFile, postCheckoutScript, { encoding: 'utf8', mode: 755 })
 
       const result = await GitProcess.exec(['checkout', 'master'], testRepoPath)
       verify(result, r => {

--- a/test/slow/git-process-test.ts
+++ b/test/slow/git-process-test.ts
@@ -158,7 +158,7 @@ describe('git-process', () => {
 echo 'post-check out hook ran'`
       const postCheckoutFile = Path.join(testRepoPath, '.git', 'hooks', 'post-checkout')
 
-      Fs.writeFileSync(postCheckoutFile, postCheckoutScript, { encoding: 'utf8', mode: 755 })
+      Fs.writeFileSync(postCheckoutFile, postCheckoutScript, { encoding: 'utf8', mode: '755' })
 
       const result = await GitProcess.exec(['checkout', 'master'], testRepoPath)
       verify(result, r => {


### PR DESCRIPTION
This was an issue reported against Desktop - https://github.com/desktop/desktop/issues/3067

The `dugite-native` package on Windows does not contain `bash.exe`, but it does have `sh.exe`, so prefixing it to the PATH provided to Git means that the commit scripts will work fine.

