### PR TITLE
don't block installation on unsupported platforms

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -4,7 +4,7 @@ There are some ways you can change the behaviour of `dugite` by providing
 environment variables. These are grouped into two categories - when you
 install `dugite` into a package, and when you spawn Git using `GitProcess`.
 
-## Install Time
+## Installation
 
 If `DUGITE_CACHE_DIR` is specified, this directory is used when installing the
 package to cache the platform-specific upstream packages containing the Git
@@ -14,8 +14,35 @@ should be cached to speed up testing.
 If this is not specified, it will fallback to [`os.tmpdir()`](https://nodejs.org/dist/latest-v8.x/docs/api/os.html#os_os_tmpdir)
 which is provided by Node.
 
-## Runtime
+## Execution
 
-TODO: `LOCAL_GIT_DIRECTORY`
+If you have a separate Git distribution you would prefer to use with `dugite`,
+you can enable this by setting these two environment variables.
 
-TODO: `GIT_EXEC_PATH`
+ - `LOCAL_GIT_DIRECTORY` - this represents the root location of Git (i.e. the
+    directory containing `bin/git`)
+ - `GIT_EXEC_PATH` - this represents where Git's subprograms are located (Git
+    can be compiled to use a given path, and some distributors will move these
+    programs to a different location)
+
+To simplify this setup, you can use the `find-git-exec` module.
+
+Here's some example code:
+
+```ts
+import { dirname } from 'path'
+import { default as findGit, Git } from 'find-git-exec'
+
+let git: Git | undefined = undefined
+
+try {
+  git = await findGit()
+} catch {}
+
+if (git.path && git.execPath) {
+  const { path, execPath } = git
+  // Set the environment variable to be able to use an external Git.
+  process.env.GIT_EXEC_PATH = execPath
+  process.env.LOCAL_GIT_DIRECTORY = dirname(dirname(path))
+}
+```

--- a/script/config.js
+++ b/script/config.js
@@ -29,23 +29,25 @@ function getConfig() {
     process.exit(1)
   }
 
-  // compute the filename from the download source
-  const url = URL.parse(config.source)
-  const pathName = url.pathname
-  const index = pathName.lastIndexOf('/')
-  config.fileName = pathName.substr(index + 1)
+  if (config.source !== '') {
+    // compute the filename from the download source
+    const url = URL.parse(config.source)
+    const pathName = url.pathname
+    const index = pathName.lastIndexOf('/')
+    config.fileName = pathName.substr(index + 1)
 
-  const cacheDirEnv = process.env.DUGITE_CACHE_DIR
+    const cacheDirEnv = process.env.DUGITE_CACHE_DIR
 
-  const cacheDir = cacheDirEnv ? path.resolve(cacheDirEnv) : os.tmpdir()
+    const cacheDir = cacheDirEnv ? path.resolve(cacheDirEnv) : os.tmpdir()
 
-  try {
-    fs.statSync(cacheDir)
-  } catch (e) {
-    fs.mkdirSync(cacheDir)
+    try {
+      fs.statSync(cacheDir)
+    } catch (e) {
+      fs.mkdirSync(cacheDir)
+    }
+
+    config.tempFile = path.join(cacheDir, config.fileName)
   }
-
-  config.tempFile = path.join(cacheDir, config.fileName)
 
   return config
 }

--- a/script/config.js
+++ b/script/config.js
@@ -24,6 +24,9 @@ function getConfig() {
     config.checksum = '7e7f2c78b994017026c4ce2d999fad25501a5a33b6c2c0c11684f58d3ccfc06b'
     config.source =
       'https://github.com/desktop/dugite-native/releases/download/v2.15.0-rc1/dugite-native-v2.15.0-ubuntu-25.tar.gz'
+  } else {
+    console.log(`Unable to install dugite for platform ${process.platform} as it is not supported.`)
+    process.exit(1)
   }
 
   // compute the filename from the download source

--- a/script/config.js
+++ b/script/config.js
@@ -24,9 +24,6 @@ function getConfig() {
     config.checksum = '7e7f2c78b994017026c4ce2d999fad25501a5a33b6c2c0c11684f58d3ccfc06b'
     config.source =
       'https://github.com/desktop/dugite-native/releases/download/v2.15.0-rc1/dugite-native-v2.15.0-ubuntu-25.tar.gz'
-  } else {
-    console.log(`Unable to install dugite for platform ${process.platform} as it is not supported.`)
-    process.exit(1)
   }
 
   if (config.source !== '') {

--- a/script/download-git.js
+++ b/script/download-git.js
@@ -99,7 +99,15 @@ const downloadAndUnpack = () => {
   })
 }
 
-mkdirp(config.outputPath, function (error) {
+if (config.source === '') {
+  console.log(
+    `Skipping downloading embedded Git as platform '${process.platform}' is not supported.`
+  )
+  console.log(`To learn more about using dugite with a system Git: https://git.io/vF5oj`)
+  process.exit(0)
+}
+
+mkdirp(config.outputPath, function(error) {
   if (error) {
     console.log(`Unable to create directory at ${config.outputPath}`, error)
     process.exit(1)


### PR DESCRIPTION
Fixes #146:

- [x] only download if a source is defined
- [x] for other platforms, point over to resource about environment variables
- [x] finish documentation about environment variables