### PR TITLE
Improve error message for timeouts when downloading git

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -14,6 +14,10 @@ should be cached to speed up testing.
 If this is not specified, it will fallback to [`os.tmpdir()`](https://nodejs.org/dist/latest-v8.x/docs/api/os.html#os_os_tmpdir)
 which is provided by Node.
 
+If you are connected to the internet using a proxy, make sure that `HTTP_PROXY`
+and `HTTPS_PROXY` are configured correctly. Otherwise the installation will fail
+with a connection error. For more information see: [Controlling proxy behaviour using environment variables](https://github.com/request/request#controlling-proxy-behaviour-using-environment-variables)
+
 ## Runtime
 
 TODO: `LOCAL_GIT_DIRECTORY`

--- a/script/download-git.js
+++ b/script/download-git.js
@@ -10,8 +10,8 @@ const zlib = require('zlib')
 
 const config = require('./config')()
 
-function extract (source, callback) {
-  const extractor = tar.Extract({path: config.outputPath})
+function extract(source, callback) {
+  const extractor = tar.Extract({ path: config.outputPath })
     .on('error', function (error) { callback(error) })
     .on('end', function () { callback() })
 
@@ -60,7 +60,16 @@ const downloadAndUnpack = () => {
   req.pipe(fs.createWriteStream(config.tempFile))
 
   req.on('error', function (error) {
-    console.log(`Error raised while downloading ${config.source}`, error)
+    if (error.code === 'ETIMEDOUT') {
+      console.log(
+        `A timeout has occurred while downloading '${config.source}' - check ` +
+        `your internet connection and try again. If you are using a proxy, ` +
+        `make sure that the HTTP_PROXY and HTTPS_PROXY environment variables are set.`,
+        error
+      )
+    } else {
+      console.log(`Error raised while downloading ${config.source}`, error)
+    }
     process.exit(1)
   })
 


### PR DESCRIPTION
This adds a specific error message for the case that the git download fails due to a timeout. It also adds a note that the cause could be an inadequate proxy configuration.

The documentation was also extended to make mention of the environment variables that need to be configured if you are using a proxy.

This is related to issue #148