### PR TITLE
Fix Git path on Android 

### DIFF
--- a/lib/git-environment.ts
+++ b/lib/git-environment.ts
@@ -26,7 +26,11 @@ function resolveGitDir(): string {
  */
 function resolveGitBinary(): string {
   const gitDir = resolveGitDir()
-  if (process.platform === 'darwin' || process.platform === 'linux') {
+  if (
+    process.platform === 'darwin' ||
+    process.platform === 'linux' ||
+    process.platform === 'android'
+  ) {
     return path.join(gitDir, 'bin', 'git')
   } else if (process.platform === 'win32') {
     return path.join(gitDir, 'cmd', 'git.exe')
@@ -46,7 +50,11 @@ function resolveGitExecPath(): string {
     return path.resolve(process.env.GIT_EXEC_PATH)
   }
   const gitDir = resolveGitDir()
-  if (process.platform === 'darwin' || process.platform === 'linux') {
+  if (
+    process.platform === 'darwin' ||
+    process.platform === 'linux' ||
+    process.platform === 'android'
+  ) {
     return path.join(gitDir, 'libexec', 'git-core')
   } else if (process.platform === 'win32') {
     return path.join(gitDir, 'mingw64', 'libexec', 'git-core')


### PR DESCRIPTION
Since Android is an Unix OS, we can use the same path as Linux and OSX.

Fixes #146