### PR TITLE
experiment: enable DEBUG mode for better tracing

### DIFF
--- a/lib/git-process.ts
+++ b/lib/git-process.ts
@@ -1,4 +1,6 @@
 import * as fs from 'fs'
+import * as debug from 'debug'
+const process = debug('DUGITE:PROCESS')
 
 import { execFile, spawn, ExecOptionsWithStringEncoding } from 'child_process'
 import {
@@ -162,12 +164,17 @@ export class GitProcess {
         env
       }
 
+      process('execFile')
+
       const spawnedProcess = execFile(gitLocation, args, execOptions, function(
         err: Error | null,
         stdout,
         stderr
       ) {
+        process('execFile completed')
+
         if (!err) {
+          process('resolved with exit code: 0')
           resolve({ stdout, stderr, exitCode: 0 })
           return
         }
@@ -195,8 +202,10 @@ export class GitProcess {
             const error = new Error(message) as ErrorWithCode
             error.name = err.name
             error.code = code
+            process(`rejecting with exit code: ${code}`)
             reject(error)
           } else {
+            process(`rejecting with unknown exit code`)
             reject(err)
           }
 
@@ -212,6 +221,7 @@ export class GitProcess {
         // as we don't know how many bytes it requires, rethrow the error with
         // details about what it was previously set to...
         if (err.message === 'stdout maxBuffer exceeded') {
+          process(`rejecting with stdout maxBuffer exceeded' error`)
           reject(
             new Error(
               `The output from the command could not fit into the allocated stdout buffer. Set options.maxBuffer to a larger value than ${
@@ -220,6 +230,7 @@ export class GitProcess {
             )
           )
         } else {
+          process(`rejecting with unknown error`)
           reject(err)
         }
       })

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,12 @@
       "integrity": "sha1-K+TcUdvn8yfQO1MxT724bvOL/Lg=",
       "dev": true
     },
+    "@types/debug": {
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-0.0.30.tgz",
+      "integrity": "sha512-orGL5LXERPYsLov6CWs3Fh6203+dXzJkR7OnddIr2514Hsecwc8xRpzCapshBbKFImCsvS/mk6+FWiN5LyZJAQ==",
+      "dev": true
+    },
     "@types/form-data": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
@@ -378,7 +384,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
       "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -730,8 +735,7 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "oauth-sign": {
       "version": "0.8.2",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "homepage": "https://github.com/desktop/dugite#readme",
   "dependencies": {
     "checksum": "^0.1.1",
+    "debug": "^3.1.0",
     "mkdirp": "^0.5.1",
     "progress": "^2.0.0",
     "request": "^2.83.0",
@@ -42,6 +43,7 @@
   "devDependencies": {
     "@types/chai": "^4.0.5",
     "@types/checksum": "^0.1.30",
+    "@types/debug": "0.0.30",
     "@types/mkdirp": "^0.5.1",
     "@types/mocha": "^2.2.44",
     "@types/node": "^8.0.53",


### PR DESCRIPTION
This is a proposal to investigate #147 by using `debug` to enable better tracing of the internals. Currently it's just focused on `execFile` (the best lead for where this is lurking) but we can probably leverage this better to help with tracing.

To enable this, you need to set the `DEBUG` environment variable to some value that interacts nicely with `dugite`. I've reserved the `DUGITE` prefix here, so `DUGITE:*` as a convention should enable full tracing, or you can opt-in for specific tracing.

If you set the `DEBUG` environment variable to `DUGITE:*`  and run the local test suite in a TTY-enabled terminal (like CMD or PowerShell on Windows), you'll see some output like this:

<img width="752" src="https://user-images.githubusercontent.com/359239/34346715-9d3607ac-ea4a-11e7-9263-5a2281f87ea9.png">

If you don't run this in a TTY-enabled terminal (like Git Bash), you'll still get some output - just not so pretty:

<img width="422" src="https://user-images.githubusercontent.com/359239/34346714-9cfeb7f2-ea4a-11e7-85b0-dd7d97c7c72a.png">

TODO: 

 - [x] add tracing to `exec` API
 - [ ] confirm this helps address #147 
 - [ ] add tracing to `spawn` API
 - [ ] test how this affects running in Electron (it should be disabled by default)