### PR TITLE
Don't rely on truthiness

### DIFF
--- a/lib/git-process.ts
+++ b/lib/git-process.ts
@@ -224,7 +224,7 @@ export class GitProcess {
         }
       })
 
-      if (options && options.stdin) {
+      if (options && options.stdin !== undefined) {
         // See https://github.com/nodejs/node/blob/7b5ffa46fe4d2868c1662694da06eb55ec744bde/test/parallel/test-stdin-pipe-large.js
         spawnedProcess.stdin.end(options.stdin, options.stdinEncoding)
       }


### PR DESCRIPTION
I ran into this today while needing to shell out to a git command with an empty stdin (but I still needed there to be an open and subsequent close of stdin).

The truthiness check for `options.stdin` fails for empty strings as yabbascript thinks that's equalish to false. This change makes it so that only when the user omits to pass a value for stdin do we skip closing stdin.