### PR TITLE
Ignore EPIPE and EOF errors on child stdin stream

### DIFF
--- a/lib/git-process.ts
+++ b/lib/git-process.ts
@@ -8,7 +8,6 @@ import {
   GitNotFoundErrorCode
 } from './errors'
 import { ChildProcess } from 'child_process'
-import { Stream } from 'stream'
 
 import { setupEnvironment } from './git-environment'
 
@@ -125,7 +124,7 @@ export class GitProcess {
 
     const spawnedProcess = spawn(gitLocation, args, spawnArgs)
 
-    ignoreClosedStreamErrors(spawnedProcess)
+    ignoreClosedInputStream(spawnedProcess)
 
     return spawnedProcess
   }
@@ -227,7 +226,7 @@ export class GitProcess {
         }
       })
 
-      ignoreClosedStreamErrors(spawnedProcess)
+      ignoreClosedInputStream(spawnedProcess)
 
       if (options && options.stdin !== undefined) {
         // See https://github.com/nodejs/node/blob/7b5ffa46fe4d2868c1662694da06eb55ec744bde/test/parallel/test-stdin-pipe-large.js
@@ -280,22 +279,15 @@ export class GitProcess {
  *
  * See https://github.com/desktop/desktop/pull/4027#issuecomment-366213276
  */
-function ignoreClosedStreamErrors(process: ChildProcess) {
-  // Suppress errors that we'd expect to see when the input
-  // stream closes abruptly, i.e. EPIPE on macOS and EOF on Windows.
-  suppressStreamErrors(process.stdin, 'EPIPE', 'EOF')
-
-  // Suppress errors that we'd expect to see when one of the
-  // output streams closes abruptly.
-  suppressStreamErrors(process.stdout, 'ECONNRESET')
-  suppressStreamErrors(process.stderr, 'ECONNRESET')
-}
-
-function suppressStreamErrors(stream: Stream, ...errorCodes: string[]) {
-  stream.on('error', err => {
+function ignoreClosedInputStream(process: ChildProcess) {
+  process.stdin.on('error', err => {
     const code = (err as ErrorWithCode).code
 
-    if (typeof code === 'string' && errorCodes.indexOf(code) !== -1) {
+    // Is the error one that we'd expect from the input stream being
+    // closed, i.e. EPIPE on macOS and EOF on Windows. We've also
+    // seen ECONNRESET failures on Linux hosts so let's throw that in
+    // there for good measure.
+    if (code === 'EPIPE' || code === 'EOF' || code === 'ECONNRESET') {
       return
     }
 
@@ -307,7 +299,7 @@ function suppressStreamErrors(stream: Stream, ...errorCodes: string[]) {
     //
     // "For all EventEmitter objects, if an 'error' event handler is not
     //  provided, the error will be thrown"
-    if (stream.listeners('error').length <= 1) {
+    if (process.stdin.listeners('error').length <= 1) {
       throw err
     }
   })

--- a/lib/git-process.ts
+++ b/lib/git-process.ts
@@ -297,7 +297,7 @@ function ignoreClosedInputStream(process: ChildProcess) {
     //
     // "For all EventEmitter objects, if an 'error' event handler is not
     //  provided, the error will be thrown"
-    if (process.stdin.listeners('error').length > 1) {
+    if (process.stdin.listeners('error').length <= 1) {
       throw err
     }
   })

--- a/lib/git-process.ts
+++ b/lib/git-process.ts
@@ -188,7 +188,7 @@ export class GitProcess {
               message = 'Unable to find path to repository on disk.'
               code = RepositoryDoesNotExistErrorCode
             } else {
-              }'. This might be a problem with how the application is packaged, so confirm this folder hasn't been removed when packaging.`
+              message = `Git could not be found at the expected path: '${gitLocation}'. This might be a problem with how the application is packaged, so confirm this folder hasn't been removed when packaging.`
               code = GitNotFoundErrorCode
             }
 

--- a/lib/git-process.ts
+++ b/lib/git-process.ts
@@ -188,7 +188,9 @@ export class GitProcess {
               message = 'Unable to find path to repository on disk.'
               code = RepositoryDoesNotExistErrorCode
             } else {
-              message = `Git could not be found at the expected path: '${gitLocation}'. This might be a problem with how the application is packaged, so confirm this folder hasn't been removed when packaging.`
+              message = `Git could not be found at the expected path: '${
+                gitLocation
+              }'. This might be a problem with how the application is packaged, so confirm this folder hasn't been removed when packaging.`
               code = GitNotFoundErrorCode
             }
 

--- a/lib/git-process.ts
+++ b/lib/git-process.ts
@@ -279,22 +279,24 @@ export class GitProcess {
  */
 function ignoreClosedInputStream(process: ChildProcess) {
   process.stdin.on('error', (err) => {
-    const errWithCode = err as ErrorWithCode
+    const code = (err as ErrorWithCode).code
 
     // Is the error one that we'd expect from the input stream being
     // closed, i.e. EPIPE on macOS and EOF on Windows?
-    if (errWithCode.code !== 'EPIPE' && errWithCode.code !== 'EOF') {
-      // Nope, this is something else. Are there any other error listeners
-      // attached than us? If not we'll have to mimic the behavior of
-      // EventEmitter.
-      //
-      // See https://nodejs.org/api/errors.html#errors_error_propagation_and_interception
-      //
-      // "For all EventEmitter objects, if an 'error' event handler is not
-      //  provided, the error will be thrown"
-      if (process.stdin.listeners('error').length > 1) {
-        throw err
-      }
+    if (code === 'EPIPE' || code === 'EOF') {
+      return
+    }
+
+    // Nope, this is something else. Are there any other error listeners
+    // attached than us? If not we'll have to mimic the behavior of
+    // EventEmitter.
+    //
+    // See https://nodejs.org/api/errors.html#errors_error_propagation_and_interception
+    //
+    // "For all EventEmitter objects, if an 'error' event handler is not
+    //  provided, the error will be thrown"
+    if (process.stdin.listeners('error').length > 1) {
+      throw err
     }
   })
 }

--- a/lib/git-process.ts
+++ b/lib/git-process.ts
@@ -188,8 +188,6 @@ export class GitProcess {
               message = 'Unable to find path to repository on disk.'
               code = RepositoryDoesNotExistErrorCode
             } else {
-              message = `Git could not be found at the expected path: '${
-                gitLocation
               }'. This might be a problem with how the application is packaged, so confirm this folder hasn't been removed when packaging.`
               code = GitNotFoundErrorCode
             }
@@ -280,7 +278,7 @@ export class GitProcess {
  * See https://github.com/desktop/desktop/pull/4027#issuecomment-366213276
  */
 function ignoreClosedInputStream(process: ChildProcess) {
-  process.stdin.on('error', (err) => {
+  process.stdin.on('error', err => {
     const code = (err as ErrorWithCode).code
 
     // Is the error one that we'd expect from the input stream being

--- a/lib/git-process.ts
+++ b/lib/git-process.ts
@@ -284,8 +284,10 @@ function ignoreClosedInputStream(process: ChildProcess) {
     const code = (err as ErrorWithCode).code
 
     // Is the error one that we'd expect from the input stream being
-    // closed, i.e. EPIPE on macOS and EOF on Windows?
-    if (code === 'EPIPE' || code === 'EOF') {
+    // closed, i.e. EPIPE on macOS and EOF on Windows. We've also
+    // seen ECONNRESET failures on Linux hosts so let's throw that in
+    // there for good measure.
+    if (code === 'EPIPE' || code === 'EOF' || code === 'ECONNRESET') {
       return
     }
 

--- a/lib/git-process.ts
+++ b/lib/git-process.ts
@@ -276,6 +276,8 @@ export class GitProcess {
  * error for them. By supressing the stream error we can pick up on
  * the real error when the process exits when we parse the exit code
  * and the standard error.
+ *
+ * See https://github.com/desktop/desktop/pull/4027#issuecomment-366213276
  */
 function ignoreClosedInputStream(process: ChildProcess) {
   process.stdin.on('error', (err) => {

--- a/lib/git-process.ts
+++ b/lib/git-process.ts
@@ -124,6 +124,8 @@ export class GitProcess {
 
     const spawnedProcess = spawn(gitLocation, args, spawnArgs)
 
+    ignoreClosedInputStream(spawnedProcess)
+
     return spawnedProcess
   }
 
@@ -224,6 +226,8 @@ export class GitProcess {
         }
       })
 
+      ignoreClosedInputStream(spawnedProcess)
+
       if (options && options.stdin !== undefined) {
         // See https://github.com/nodejs/node/blob/7b5ffa46fe4d2868c1662694da06eb55ec744bde/test/parallel/test-stdin-pipe-large.js
         spawnedProcess.stdin.end(options.stdin, options.stdinEncoding)
@@ -246,4 +250,51 @@ export class GitProcess {
 
     return null
   }
+}
+
+/**
+ * Prevent errors originating from the stdin stream related
+ * to the child process closing the pipe from bubbling up and
+ * causing an unhandled exception when no error handler is
+ * attached to the input stream.
+ *
+ * The common scenario where this happens is if the consumer
+ * is writing data to the stdin stream of a child process and
+ * the child process for one reason or another decides to either
+ * terminate or simply close its standard input. Imagine this
+ * scenario
+ *
+ *  cat /dev/zero | head -c 1
+ *
+ * The 'head' command would close its standard input (by terminating)
+ * the moment it has read one byte. In the case of Git this could
+ * happen if you for example pass badly formed input to apply-patch.
+ *
+ * Since consumers of dugite using the `exec` api are unable to get
+ * a hold of the stream until after we've written data to it they're
+ * unable to fix it themselves so we'll just go ahead and ignore the
+ * error for them. By supressing the stream error we can pick up on
+ * the real error when the process exits when we parse the exit code
+ * and the standard error.
+ */
+function ignoreClosedInputStream(process: ChildProcess) {
+  process.stdin.on('error', (err) => {
+    const errWithCode = err as ErrorWithCode
+
+    // Is the error one that we'd expect from the input stream being
+    // closed, i.e. EPIPE on macOS and EOF on Windows?
+    if (errWithCode.code !== 'EPIPE' && errWithCode.code !== 'EOF') {
+      // Nope, this is something else. Are there any other error listeners
+      // attached than us? If not we'll have to mimic the behavior of
+      // EventEmitter.
+      //
+      // See https://nodejs.org/api/errors.html#errors_error_propagation_and_interception
+      //
+      // "For all EventEmitter objects, if an 'error' event handler is not
+      //  provided, the error will be thrown"
+      if (process.stdin.listeners('error').length > 1) {
+        throw err
+      }
+    }
+  })
 }

--- a/test/fast/git-process-test.ts
+++ b/test/fast/git-process-test.ts
@@ -36,13 +36,9 @@ describe('git-process', () => {
       // and then try to write to stdin. Without the ignoreClosedInputStream
       // workaround this will crash the process (timing related) with an
       // EPIPE/EOF error thrown from process.stdin
-      const result = await GitProcess.exec(
-        ['--trololol'],
-        testRepoPath,
-        {
-          stdin: '\n'.repeat(1024 * 1024)
-        }
-      )
+      const result = await GitProcess.exec(['--trololol'], testRepoPath, {
+        stdin: '\n'.repeat(1024 * 1024)
+      })
       verify(result, r => {
         expect(r.exitCode).to.equal(129)
       })

--- a/test/fast/git-process-test.ts
+++ b/test/fast/git-process-test.ts
@@ -29,6 +29,25 @@ describe('git-process', () => {
       })
     })
 
+    it('handles stdin closed errors', async () => {
+      const testRepoPath = temp.mkdirSync('desktop-git-test-blank')
+
+      // Pass an unknown arg to Git, forcing it to terminate immediately
+      // and then try to write to stdin. Without the ignoreClosedInputStream
+      // workaround this will crash the process (timing related) with an
+      // EPIPE/EOF error thrown from process.stdin
+      const result = await GitProcess.exec(
+        ['--trololol'],
+        testRepoPath,
+        {
+          stdin: '\n'.repeat(1024 * 1024)
+        }
+      )
+      verify(result, r => {
+        expect(r.exitCode).to.equal(129)
+      })
+    })
+
     describe('diff', () => {
       it('returns expected error code for initial commit when creating diff', async () => {
         const testRepoPath = await initialize('blank-no-commits')


### PR DESCRIPTION
This was discussed in https://github.com/desktop/desktop/pull/4027#issuecomment-366213276.

If a child process closes stdin or terminates while a stream write operation is in progress the error from stdin closing will be thrown before the exit callback on the process. Without an error handler subscribed to the stream the default behavior of Node is to re-throw the error which then ends up in the global uncaught error handler and then we crash (and by we I mean desktop/desktop).

The context should be fairly well laid out in the PR itself.