### PR TITLE
bump the native package

### DIFF
--- a/script/config.js
+++ b/script/config.js
@@ -13,17 +13,17 @@ function getConfig() {
   }
 
   if (process.platform === 'darwin') {
-    config.checksum = '30eb68d28bbb9c88e644ad3c025c4e0bbf43b77317a346d342c449a52143b1a7'
+    config.checksum = '65d608eb16e0e262bae6bd7828b28cf640455e949003fec94c1233e084b9ccde'
     config.source =
-      'https://github.com/desktop/dugite-native/releases/download/v2.16.1/dugite-native-v2.16.1-macOS-75.tar.gz'
+      'https://github.com/desktop/dugite-native/releases/download/v2.16.2/dugite-native-v2.16.2-macOS-119.tar.gz'
   } else if (process.platform === 'win32') {
-    config.checksum = '856b5ff7b791210b5bf8f3a9daab03be02b020823c568ef2aa60f906c1a978e6'
+    config.checksum = 'c84d31baa8d5c782bbf2a421c0231895c8515b09f698653d70e491b4ffdc1db3'
     config.source =
-      'https://github.com/desktop/dugite-native/releases/download/v2.16.1/dugite-native-v2.16.1-win32-75.tar.gz'
+      'https://github.com/desktop/dugite-native/releases/download/v2.16.2/dugite-native-v2.16.2-win32-119.tar.gz'
   } else if (process.platform === 'linux') {
-    config.checksum = 'fefb2675957a2b878eb792b176ef801058772679e8472af9585b02521656509e'
+    config.checksum = '831dddd2381bb7a85f45b35911f123d062a2bdacf2116181503a1293e58a6e79'
     config.source =
-      'https://github.com/desktop/dugite-native/releases/download/v2.16.1/dugite-native-v2.16.1-ubuntu-75.tar.gz'
+      'https://github.com/desktop/dugite-native/releases/download/v2.16.2/dugite-native-v2.16.2-ubuntu-119.tar.gz'
   }
 
   if (config.source !== '') {

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,7 +1,7 @@
 import { GitProcess, IGitResult } from '../lib'
 
 // NOTE: bump these versions to the latest stable releases
-export const gitVersion = '2.16.1'
+export const gitVersion = '2.16.2'
 export const gitLfsVersion = '2.3.4'
 
 const temp = require('temp').track()


### PR DESCRIPTION
This gets us up to Git `v2.16.2` which has a few updates:

 - [Git release notes](https://github.com/git/git/blob/master/Documentation/RelNotes/2.16.2.txt)
 - [Git for Windows release notes](https://github.com/git-for-windows/git/releases/tag/v2.16.2.windows.1)
