### PR TITLE
simplify CI build steps and test against Node v9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,8 @@ branches:
 
 language: node_js
 node_js:
-  - "6"
-  - "7"
   - "8"
+  - "9"
 
 cache:
   timeout: 600
@@ -27,7 +26,7 @@ cache:
     - $HOME/.dugite/
 
 install:
-  - npm install -g npm@5.5.1
+  - npm install -g npm@5.7.1
   - npm install
   - npm run build
   - npm run is-it-pretty

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,9 +5,8 @@ platform:
 
 environment:
   matrix:
-    - nodejs_version: "6"
-    - nodejs_version: "7"
     - nodejs_version: "8"
+    - nodejs_version: "9"
   DUGITE_CACHE_DIR: '%USERPROFILE%\.dugite\'
 
 cache:
@@ -24,7 +23,7 @@ version: "{build}"
 
 install:
   - ps: Install-Product node $env:nodejs_version $env:platform
-  - npm install -g npm@5.5.1
+  - npm install -g npm@5.7.1
   - npm install
   - npm run is-it-pretty
 

--- a/test/slow/node-shenanigans.ts
+++ b/test/slow/node-shenanigans.ts
@@ -1,21 +1,25 @@
-describe('node shenanigans', () => {
-  it('will fail to encode the maximum buffer length', done => {
-    // this is the magic number according to https://github.com/nodejs/node/issues/3175
-    // 256MB = 268435456 bytes
-    // 268435441 bytes = 256MB - 15 bytes
-    const buffer = Buffer.alloc(268435441)
+// this appears to be fixed in v9, so we no longer need to test this corner
+// case there
+if (process.versions.node[0] !== '9') {
+  describe('node shenanigans', () => {
+    it('will fail to encode the maximum buffer length', done => {
+      // this is the magic number according to https://github.com/nodejs/node/issues/3175
+      // 256MB = 268435456 bytes
+      // 268435441 bytes = 256MB - 15 bytes
+      const buffer = Buffer.alloc(268435441)
 
-    // Ensure it's filled with a valid character
-    buffer.fill('a')
+      // Ensure it's filled with a valid character
+      buffer.fill('a')
 
-    try {
-      buffer.toString('utf-8')
-    } catch {
-      // we expect this to happen
-      done()
-      return
-    }
+      try {
+        buffer.toString('utf-8')
+      } catch {
+        // we expect this to happen
+        done()
+        return
+      }
 
-    done(new Error('The buffer was converted correctly, which should never happen'))
+      done(new Error('The buffer was converted correctly, which should never happen'))
+    })
   })
-})
+}


### PR DESCRIPTION
v8 is now LTS and v9 is the current version - only test against those to keep things simple.

Also bumps npm to the latest version, just in case.