### PR TITLE
Added the enum and regex for when a branch rename command fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ branches:
 
 language: node_js
 node_js:
-  - "8"
+  - "8.9.4"
   - "9"
 
 cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ platform:
 
 environment:
   matrix:
-    - nodejs_version: "8"
+    - nodejs_version: "8.9.4"
     - nodejs_version: "9"
   DUGITE_CACHE_DIR: '%USERPROFILE%\.dugite\'
 

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -30,6 +30,7 @@ export enum GitError {
   NotAGitRepository,
   CannotMergeUnrelatedHistories,
   LFSAttributeDoesNotMatch,
+  BranchRenameFailed,
   // GitHub-specific error codes
   PushWithFileSizeExceedingLimit,
   HexBranchNameRejected,
@@ -88,6 +89,7 @@ export const GitErrorRegexes = {
     GitError.NotAGitRepository,
   'fatal: refusing to merge unrelated histories': GitError.CannotMergeUnrelatedHistories,
   'The .+ attribute should be .+ but is .+': GitError.LFSAttributeDoesNotMatch,
+  'fatal: Branch rename failed': GitError.BranchRenameFailed,
   // GitHub-specific errors
   'error: GH001: ': GitError.PushWithFileSizeExceedingLimit,
   'error: GH002: ': GitError.HexBranchNameRejected,

--- a/test/fast/git-process-test.ts
+++ b/test/fast/git-process-test.ts
@@ -242,5 +242,13 @@ remote: http://github.com/settings/emails`
       const error = GitProcess.parseError(stderr)
       expect(error).to.equal(GitError.LFSAttributeDoesNotMatch)
     })
+
+    it('can parse rename Branch error', () => {
+      const stderr = `error: refname refs/heads/adding-renamefailed-error not found
+      fatal: Branch rename failed`
+
+      const error = GitProcess.parseError(stderr)
+      expect(error).to.equal(GitError.BranchRenameFailed)
+    })
   })
 })


### PR DESCRIPTION
So I noticed that the rename branch error is not included and added it. 

I can submit more if I find any, unless that is something the project is not looking for?