### PR TITLE
Add test to ensure sslCAInfo is unset

### DIFF
--- a/test/fast/config-test.ts
+++ b/test/fast/config-test.ts
@@ -11,4 +11,11 @@ describe('config', () => {
       expect(result.stdout.trim()).to.equal('schannel')
     }
   })
+
+  it('unsets http.sslCAInfo on Windows', async () => {
+    if (process.platform === 'win32') {
+      const result = await GitProcess.exec(['config', '--system', 'http.sslCAInfo'], os.homedir())
+      expect(result.stdout.trim()).to.equal('')
+    }
+  })
 })


### PR DESCRIPTION
Adds test to ensure `http.sslCAInfo` is unset for Windows.

This came up while @niik, @nerdneha, and I were pairing on getting dugite updated so cURL/schannel defaults to using the Windows certificate store.