### PR TITLE
add tests for old and new format of "not a git repo" message

### DIFF
--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -89,7 +89,7 @@ export const GitErrorRegexes = {
     GitError.PatchDoesNotApply,
   "fatal: A branch named '(.+)' already exists.": GitError.BranchAlreadyExists,
   "fatal: bad revision '(.*)'": GitError.BadRevision,
-  'fatal: Not a git repository \\(or any of the parent directories\\): (.*)':
+  'fatal: [Nn]ot a git repository \\(or any of the parent directories\\): (.*)':
     GitError.NotAGitRepository,
   'fatal: refusing to merge unrelated histories': GitError.CannotMergeUnrelatedHistories,
   'The .+ attribute should be .+ but is .+': GitError.LFSAttributeDoesNotMatch,

--- a/test/fast/git-process-test.ts
+++ b/test/fast/git-process-test.ts
@@ -372,5 +372,19 @@ remove the file manually to continue.`
       const error = GitProcess.parseError(stderr)
       expect(error).to.equal(GitError.LockFileAlreadyExists)
     })
+
+    it('can parse the previous not found repository error', () => {
+      const stderr = 'fatal: Not a git repository (or any of the parent directories): .git'
+
+      const error = GitProcess.parseError(stderr)
+      expect(error).to.equal(GitError.NotAGitRepository)
+    })
+
+    it('can parse the current found repository error', () => {
+      const stderr = 'fatal: not a git repository (or any of the parent directories): .git'
+
+      const error = GitProcess.parseError(stderr)
+      expect(error).to.equal(GitError.NotAGitRepository)
+    })
   })
 })


### PR DESCRIPTION
This message changed in https://github.com/git-for-windows/git/commit/fc045fe7d4fa220f19274715c936636fe0516ea3 version 2.17.1, and we need to handle the new format.

  - [x] see failing test
  - [x] fix failing test