### PR TITLE
Allow Unsupported platforms to run, when Environment variables are set.

### DIFF
--- a/lib/git-environment.ts
+++ b/lib/git-environment.ts
@@ -1,10 +1,18 @@
 import * as path from 'path'
 
 function resolveEmbeddedGitDir(): string {
-  const s = path.sep
-  return path
-    .resolve(__dirname, '..', '..', 'git')
-    .replace(/[\\\/]app.asar[\\\/]/, `${s}app.asar.unpacked${s}`)
+  if (
+    process.platform === 'darwin' ||
+    process.platform === 'linux' ||
+    process.platform === 'android' ||
+    process.platform === 'win32'
+  ) {
+    const s = path.sep
+    return path
+      .resolve(__dirname, '..', '..', 'git')
+      .replace(/[\\\/]app.asar[\\\/]/, `${s}app.asar.unpacked${s}`)
+  }
+  throw new Error('Git not supported on platform: ' + process.platform)
 }
 
 /**
@@ -26,17 +34,11 @@ function resolveGitDir(): string {
  */
 function resolveGitBinary(): string {
   const gitDir = resolveGitDir()
-  if (
-    process.platform === 'darwin' ||
-    process.platform === 'linux' ||
-    process.platform === 'android'
-  ) {
-    return path.join(gitDir, 'bin', 'git')
-  } else if (process.platform === 'win32') {
+  if (process.platform === 'win32') {
     return path.join(gitDir, 'cmd', 'git.exe')
+  } else {
+    return path.join(gitDir, 'bin', 'git')
   }
-
-  throw new Error('Git not supported on platform: ' + process.platform)
 }
 
 /**
@@ -50,17 +52,11 @@ function resolveGitExecPath(): string {
     return path.resolve(process.env.GIT_EXEC_PATH)
   }
   const gitDir = resolveGitDir()
-  if (
-    process.platform === 'darwin' ||
-    process.platform === 'linux' ||
-    process.platform === 'android'
-  ) {
-    return path.join(gitDir, 'libexec', 'git-core')
-  } else if (process.platform === 'win32') {
+  if (process.platform === 'win32') {
     return path.join(gitDir, 'mingw64', 'libexec', 'git-core')
+  } else {
+    return path.join(gitDir, 'libexec', 'git-core')
   }
-
-  throw new Error('Git not supported on platform: ' + process.platform)
 }
 
 /**


### PR DESCRIPTION
I develop on OpenBSD and one of the packages i have taken an interest in, uses [surf](https://github.com/surf-build/surf) for continuous integration, relying on dugite for git support.

When i initially looked at the problem i thought i could set `GIT_EXEC_PATH` and `LOCAL_GIT_DIRECTORY` and things might work, but i hit some `throw new Error('Git not supported on platform: ' + process.platform)` errors.

With these changes and when the environment variables are set, the `Git not supported on platform` are not hit and dugite uses my installed git package, with the environment variables not set there is no functionally change.

I did the following changed.
Move platform check and Error into resolveEmbeddedGitDir, so if the
Environment variable 'LOCAL_GIT_DIRECTORY' is set, the error `throw new Error('Git not supported on platform: ' + process.platform)` is still executed.

Change path.join to set git-core and git to be if win32 else 'others' (with others being Unixes)

I didn't want to just target OpenBSD as i know of other developments using FreeBSD will also be impacted.

I know OpenBSD (and FreeBSD) are not supported and don't expect support, but by having these changes unsupported platforms have a chance of running.

[Edit] I have tested this change on OpenBSD and Windows.