### PR TITLE
add NoMergeToAbortError

### DIFF
--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -35,6 +35,7 @@ export enum GitError {
   InvalidObjectName,
   OutsideRepository,
   LockFileAlreadyExists,
+  NoMergeToAbort,
   // GitHub-specific error codes
   PushWithFileSizeExceedingLimit,
   HexBranchNameRejected,
@@ -112,7 +113,8 @@ export const GitErrorRegexes = {
     GitError.ProtectedBranchDeleteRejected,
   'error: GH006: Protected branch update failed for (.+).\nremote: error: Required status check "(.+)" is expected':
     GitError.ProtectedBranchRequiredStatus,
-  'error: GH007: Your push would publish a private email address.': GitError.PushWithPrivateEmail
+  'error: GH007: Your push would publish a private email address.': GitError.PushWithPrivateEmail,
+  'fatal: There is no merge to abort (MERGE_HEAD missing).': GitError.NoMergeToAbort
 }
 
 /**

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -100,6 +100,7 @@ export const GitErrorRegexes = {
   "fatal: .+: '(.+)' is outside repository": GitError.OutsideRepository,
   'Another git process seems to be running in this repository, e.g.':
     GitError.LockFileAlreadyExists,
+  'fatal: There is no merge to abort': GitError.NoMergeToAbort,
   // GitHub-specific errors
   'error: GH001: ': GitError.PushWithFileSizeExceedingLimit,
   'error: GH002: ': GitError.HexBranchNameRejected,
@@ -113,8 +114,7 @@ export const GitErrorRegexes = {
     GitError.ProtectedBranchDeleteRejected,
   'error: GH006: Protected branch update failed for (.+).\nremote: error: Required status check "(.+)" is expected':
     GitError.ProtectedBranchRequiredStatus,
-  'error: GH007: Your push would publish a private email address.': GitError.PushWithPrivateEmail,
-  'fatal: There is no merge to abort (MERGE_HEAD missing).': GitError.NoMergeToAbort
+  'error: GH007: Your push would publish a private email address.': GitError.PushWithPrivateEmail
 }
 
 /**

--- a/test/fast/git-process-test.ts
+++ b/test/fast/git-process-test.ts
@@ -386,5 +386,12 @@ remove the file manually to continue.`
       const error = GitProcess.parseError(stderr)
       expect(error).to.equal(GitError.NotAGitRepository)
     })
+
+    it('can parse the no merge to abort error', () => {
+      const stderr = 'fatal: There is no merge to abort (MERGE_HEAD missing).\n'
+
+      const error = GitProcess.parseError(stderr)
+      expect(error).to.equal(GitError.NoMergeToAbort)
+    })
   })
 })


### PR DESCRIPTION
parse the error in the following case and return a `NoMergeToAbort` error

```shellsession
~/GitHub/desktop
 (master)$ git merge --abort 
fatal: There is no merge to abort (MERGE_HEAD missing).
~/GitHub/desktop
 (master)$
```