### PR TITLE
[v2] lean on the type system better around error parsing

### DIFF
--- a/docs/v2-migration-guide.md
+++ b/docs/v2-migration-guide.md
@@ -1,0 +1,47 @@
+# v2 Migration Guide
+
+## Error parsing
+
+`GitProcess.parseError` has moved to `parseError`, and the value returned by
+`parseError` is now a string enum (previously this was a number). This should
+help with improving the error handling in `dugite`, but will affect current
+users if they relied on the underlying numeric values.
+
+To help with migrating, ensure you are not comparing any error codes to their
+backing value.
+
+Instead of this:
+
+```ts
+const gitError = GitProcess.parseError(result.stderr)
+const missing = gitError && gitError === 27 // value for 'NotAGitRepository'
+```
+
+Update your pre-2.0 code to compare to the enum directly:
+
+```ts
+const gitError = GitProcess.parseError(result.stderr)
+const missing = gitError && gitError === GitError.NotAGitRepository
+```
+
+If you were somehow storing these values in a database, and need to convert them
+into the new representation, 2.0 will ship a `migrateOldErrorCode` compatibility
+function to convert to the new enum:
+
+```ts
+const oldGitError = number as GitError
+const gitError = migrateOldErrorCode(oldGitError)
+if (gitError !== null) {
+  // update storage
+} else {
+  // unknown enum value
+}
+```
+
+This will be deprecated shortly after, so if you have this issue:
+
+- upgrade to the latest `1.x` release
+- review all usages and ensure you are comparing to `GitError` values
+- upgrade to `2.0` and update all introduced compilation errors
+- update stored values to the new representation
+- upgrade to latest `2.1` version, drop any remaining usage of `migrateOldErrorCode`

--- a/examples/commit.ts
+++ b/examples/commit.ts
@@ -1,4 +1,4 @@
-import { GitProcess, GitError, IGitExecutionOptions, parseError } from '../lib/'
+import { GitProcess, parseError } from '../lib/'
 
 // for readability, let's alias this
 const git = GitProcess.exec

--- a/examples/commit.ts
+++ b/examples/commit.ts
@@ -1,4 +1,4 @@
-import { GitProcess, GitError, IGitExecutionOptions } from '../lib/'
+import { GitProcess, GitError, IGitExecutionOptions, parseError } from '../lib/'
 
 // for readability, let's alias this
 const git = GitProcess.exec
@@ -29,7 +29,7 @@ export async function createCommit(path: string, message: string) {
 
   const result = await git(['commit', '-F', '-'], path, { stdin: message })
   if (result.exitCode !== 0) {
-    const error = GitProcess.parseError(result.stderr)
+    const error = parseError(result.stderr)
     if (error) {
       console.log(`Got error code: ${error}`)
     } else {

--- a/examples/parsing-errors.ts
+++ b/examples/parsing-errors.ts
@@ -1,4 +1,4 @@
-import { GitProcess, GitError } from '../lib/'
+import { GitProcess, GitError, parseError } from '../lib/'
 
 async function getError() {
   const branch = 'master'
@@ -6,7 +6,7 @@ async function getError() {
 
   const result = await GitProcess.exec(['pull', 'origin', branch], path)
   if (result.exitCode !== 0) {
-    const error = GitProcess.parseError(result.stderr)
+    const error = parseError(result.stderr)
     if (error) {
       if (error === GitError.HTTPSAuthenticationFailed) {
         // invalid credentials

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -1,121 +1,158 @@
 /** The git errors which can be parsed from failed git commands. */
 export enum GitError {
-  SSHKeyAuditUnverified,
-  SSHAuthenticationFailed,
-  SSHPermissionDenied,
-  HTTPSAuthenticationFailed,
-  RemoteDisconnection,
-  HostDown,
-  RebaseConflicts,
-  MergeConflicts,
-  HTTPSRepositoryNotFound,
-  SSHRepositoryNotFound,
-  PushNotFastForward,
-  BranchDeletionFailed,
-  DefaultBranchDeletionFailed,
-  RevertConflicts,
-  EmptyRebasePatch,
-  NoMatchingRemoteBranch,
-  NothingToCommit,
-  NoSubmoduleMapping,
-  SubmoduleRepositoryDoesNotExist,
-  InvalidSubmoduleSHA,
-  LocalPermissionDenied,
-  InvalidMerge,
-  InvalidRebase,
-  NonFastForwardMergeIntoEmptyHead,
-  PatchDoesNotApply,
-  BranchAlreadyExists,
-  BadRevision,
-  NotAGitRepository,
-  CannotMergeUnrelatedHistories,
-  LFSAttributeDoesNotMatch,
-  BranchRenameFailed,
-  PathDoesNotExist,
-  InvalidObjectName,
-  OutsideRepository,
-  LockFileAlreadyExists,
-  NoMergeToAbort,
+  SSHKeyAuditUnverified = 'ssh-key-audit-unverified',
+  SSHAuthenticationFailed = 'ssh-authentication-failed',
+  SSHPermissionDenied = 'ssh-permission-denied',
+  HTTPSAuthenticationFailed = 'https-authentication-failed',
+  RemoteDisconnection = 'remote-disconnection',
+  HostDown = 'host-down',
+  RebaseConflicts = 'rebase-conflict',
+  MergeConflicts = 'merge-conflicts',
+  HTTPSRepositoryNotFound = 'https-repository-not-found',
+  SSHRepositoryNotFound = 'ssh-repository-not-found',
+  PushNotFastForward = 'push-not-fast-forward',
+  BranchDeletionFailed = 'branch-deletion-failed',
+  DefaultBranchDeletionFailed = 'default-branch-deletion-failed',
+  RevertConflicts = 'revert-conflicts',
+  EmptyRebasePatch = 'empty-rebase-patch',
+  NoMatchingRemoteBranch = 'no-matching-remote-branch',
+  NothingToCommit = 'nothing-to-commit',
+  NoSubmoduleMapping = 'no-submodule-mapping',
+  SubmoduleRepositoryDoesNotExist = 'submodule-repository-does-not-exist',
+  InvalidSubmoduleSHA = 'invalid-submodule-sha',
+  LocalPermissionDenied = 'local-permission-denied',
+  InvalidMerge = 'invalid-merge',
+  InvalidRebase = 'invalid-rebase',
+  NonFastForwardMergeIntoEmptyHead = 'non-fast-forward-merge-into-empty-head',
+  PatchDoesNotApply = 'patch-does-not-apply',
+  BranchAlreadyExists = 'branch-already-exists',
+  BadRevision = 'bad-revision',
+  NotAGitRepository = 'not-a-git-repository',
+  CannotMergeUnrelatedHistories = 'cannot-merge-unrelated-histories',
+  LFSAttributeDoesNotMatch = 'lfs-attribute-does-not-match',
+  BranchRenameFailed = 'branch-rename-failed',
+  PathDoesNotExist = 'path-does-not-exist',
+  InvalidObjectName = 'invalid-object-name',
+  OutsideRepository = 'outside-repository',
+  LockFileAlreadyExists = 'lock-file-already-exists',
+  NoMergeToAbort = 'no-merge-to-abort',
   // GitHub-specific error codes
-  PushWithFileSizeExceedingLimit,
-  HexBranchNameRejected,
-  ForcePushRejected,
-  InvalidRefLength,
-  ProtectedBranchRequiresReview,
-  ProtectedBranchForcePush,
-  ProtectedBranchDeleteRejected,
-  ProtectedBranchRequiredStatus,
-  PushWithPrivateEmail
+  PushWithFileSizeExceedingLimit = 'push-with-file-size-exceeding-limit',
+  HexBranchNameRejected = 'hex-branch-name-rejected',
+  ForcePushRejected = 'force-push-rejected',
+  InvalidRefLength = 'invalid-ref-length',
+  ProtectedBranchRequiresReview = 'protected-branch-requires-review',
+  ProtectedBranchForcePush = 'protected-branch-force-push',
+  ProtectedBranchDeleteRejected = 'protected-branch-delete-rejected',
+  ProtectedBranchRequiredStatus = 'protected-branch-required-status',
+  PushWithPrivateEmail = 'push-with-private-email'
 }
 
 /** A mapping from regexes to the git error they identify. */
-export const GitErrorRegexes = {
-  'ERROR: ([\\s\\S]+?)\\n+\\[EPOLICYKEYAGE\\]\\n+fatal: Could not read from remote repository.':
-    GitError.SSHKeyAuditUnverified,
-  "fatal: Authentication failed for 'https://": GitError.HTTPSAuthenticationFailed,
-  'fatal: Authentication failed': GitError.SSHAuthenticationFailed,
-  'fatal: Could not read from remote repository.': GitError.SSHPermissionDenied,
-  'The requested URL returned error: 403': GitError.HTTPSAuthenticationFailed,
-  'fatal: The remote end hung up unexpectedly': GitError.RemoteDisconnection,
-  "fatal: unable to access '(.+)': Failed to connect to (.+): Host is down": GitError.HostDown,
-  'Failed to merge in the changes.': GitError.RebaseConflicts,
-  '(Merge conflict|Automatic merge failed; fix conflicts and then commit the result)':
-    GitError.MergeConflicts,
-  "fatal: repository '(.+)' not found": GitError.HTTPSRepositoryNotFound,
-  'ERROR: Repository not found': GitError.SSHRepositoryNotFound,
-  "\\((non-fast-forward|fetch first)\\)\nerror: failed to push some refs to '.*'":
-    GitError.PushNotFastForward,
-  "error: unable to delete '(.+)': remote ref does not exist": GitError.BranchDeletionFailed,
-  '\\[remote rejected\\] (.+) \\(deletion of the current branch prohibited\\)':
-    GitError.DefaultBranchDeletionFailed,
-  "error: could not revert .*\nhint: after resolving the conflicts, mark the corrected paths\nhint: with 'git add <paths>' or 'git rm <paths>'\nhint: and commit the result with 'git commit'":
-    GitError.RevertConflicts,
-  "Applying: .*\nNo changes - did you forget to use 'git add'\\?\nIf there is nothing left to stage, chances are that something else\n.*":
-    GitError.EmptyRebasePatch,
-  'There are no candidates for (rebasing|merging) among the refs that you just fetched.\nGenerally this means that you provided a wildcard refspec which had no\nmatches on the remote end.':
-    GitError.NoMatchingRemoteBranch,
-  'nothing to commit': GitError.NothingToCommit,
-  "No submodule mapping found in .gitmodules for path '(.+)'": GitError.NoSubmoduleMapping,
-  "fatal: repository '(.+)' does not exist\nfatal: clone of '.+' into submodule path '(.+)' failed":
-    GitError.SubmoduleRepositoryDoesNotExist,
-  "Fetched in submodule path '(.+)', but it did not contain (.+). Direct fetching of that commit failed.":
-    GitError.InvalidSubmoduleSHA,
-  "fatal: could not create work tree dir '(.+)'.*: Permission denied":
-    GitError.LocalPermissionDenied,
-  'merge: (.+) - not something we can merge': GitError.InvalidMerge,
-  'invalid upstream (.+)': GitError.InvalidRebase,
-  'fatal: Non-fast-forward commit does not make sense into an empty head':
-    GitError.NonFastForwardMergeIntoEmptyHead,
-  'error: (.+): (patch does not apply|already exists in working directory)':
-    GitError.PatchDoesNotApply,
-  "fatal: A branch named '(.+)' already exists.": GitError.BranchAlreadyExists,
-  "fatal: bad revision '(.*)'": GitError.BadRevision,
-  'fatal: [Nn]ot a git repository \\(or any of the parent directories\\): (.*)':
-    GitError.NotAGitRepository,
-  'fatal: refusing to merge unrelated histories': GitError.CannotMergeUnrelatedHistories,
-  'The .+ attribute should be .+ but is .+': GitError.LFSAttributeDoesNotMatch,
-  'fatal: Branch rename failed': GitError.BranchRenameFailed,
-  "fatal: Path '(.+)' does not exist .+": GitError.PathDoesNotExist,
-  "fatal: Invalid object name '(.+)'.": GitError.InvalidObjectName,
-  "fatal: .+: '(.+)' is outside repository": GitError.OutsideRepository,
-  'Another git process seems to be running in this repository, e.g.':
-    GitError.LockFileAlreadyExists,
-  'fatal: There is no merge to abort': GitError.NoMergeToAbort,
+
+export const GitErrorRegexes = new Map<string, GitError>([
+  [
+    'ERROR: ([\\s\\S]+?)\\n+\\[EPOLICYKEYAGE\\]\\n+fatal: Could not read from remote repository.',
+    GitError.SSHKeyAuditUnverified
+  ],
+  ["fatal: Authentication failed for 'https://", GitError.HTTPSAuthenticationFailed],
+  ['fatal: Authentication failed', GitError.SSHAuthenticationFailed],
+  ['fatal: Could not read from remote repository.', GitError.SSHPermissionDenied],
+  ['The requested URL returned error: 403', GitError.HTTPSAuthenticationFailed],
+  ['fatal: The remote end hung up unexpectedly', GitError.RemoteDisconnection],
+  ["fatal: unable to access '(.+)': Failed to connect to (.+): Host is down", GitError.HostDown],
+  ['Failed to merge in the changes.', GitError.RebaseConflicts],
+  [
+    '(Merge conflict|Automatic merge failed; fix conflicts and then commit the result)',
+    GitError.MergeConflicts
+  ],
+  ["fatal: repository '(.+)' not found", GitError.HTTPSRepositoryNotFound],
+  ['ERROR: Repository not found', GitError.SSHRepositoryNotFound],
+  [
+    "\\((non-fast-forward|fetch first)\\)\nerror: failed to push some refs to '.*'",
+    GitError.PushNotFastForward
+  ],
+  ["error: unable to delete '(.+)': remote ref does not exist", GitError.BranchDeletionFailed],
+  [
+    '\\[remote rejected\\] (.+) \\(deletion of the current branch prohibited\\)',
+    GitError.DefaultBranchDeletionFailed
+  ],
+  [
+    "error: could not revert .*\nhint: after resolving the conflicts, mark the corrected paths\nhint: with 'git add <paths>' or 'git rm <paths>'\nhint: and commit the result with 'git commit'",
+    GitError.RevertConflicts
+  ],
+  [
+    "Applying: .*\nNo changes - did you forget to use 'git add'\\?\nIf there is nothing left to stage, chances are that something else\n.*",
+    GitError.EmptyRebasePatch
+  ],
+  [
+    'There are no candidates for (rebasing|merging) among the refs that you just fetched.\nGenerally this means that you provided a wildcard refspec which had no\nmatches on the remote end.',
+    GitError.NoMatchingRemoteBranch
+  ],
+  ['nothing to commit', GitError.NothingToCommit],
+  ["No submodule mapping found in .gitmodules for path '(.+)'", GitError.NoSubmoduleMapping],
+  [
+    "fatal: repository '(.+)' does not exist\nfatal: clone of '.+' into submodule path '(.+)' failed",
+    GitError.SubmoduleRepositoryDoesNotExist
+  ],
+  [
+    "Fetched in submodule path '(.+)', but it did not contain (.+). Direct fetching of that commit failed.",
+    GitError.InvalidSubmoduleSHA
+  ],
+  [
+    "fatal: could not create work tree dir '(.+)'.*: Permission denied",
+    GitError.LocalPermissionDenied
+  ],
+  ['merge: (.+) - not something we can merge', GitError.InvalidMerge],
+  ['invalid upstream (.+)', GitError.InvalidRebase],
+  [
+    'fatal: Non-fast-forward commit does not make sense into an empty head',
+    GitError.NonFastForwardMergeIntoEmptyHead
+  ],
+  [
+    'error: (.+): (patch does not apply|already exists in working directory)',
+    GitError.PatchDoesNotApply
+  ],
+  ["fatal: A branch named '(.+)' already exists.", GitError.BranchAlreadyExists],
+  ["fatal: bad revision '(.*)'", GitError.BadRevision],
+  [
+    'fatal: [Nn]ot a git repository \\(or any of the parent directories\\): (.*)',
+    GitError.NotAGitRepository
+  ],
+  ['fatal: refusing to merge unrelated histories', GitError.CannotMergeUnrelatedHistories],
+  ['The .+ attribute should be .+ but is .+', GitError.LFSAttributeDoesNotMatch],
+  ['fatal: Branch rename failed', GitError.BranchRenameFailed],
+  ["fatal: Path '(.+)' does not exist .+", GitError.PathDoesNotExist],
+  ["fatal: Invalid object name '(.+)'.", GitError.InvalidObjectName],
+  ["fatal: .+: '(.+)' is outside repository", GitError.OutsideRepository],
+  [
+    'Another git process seems to be running in this repository, e.g.',
+    GitError.LockFileAlreadyExists
+  ],
+  ['fatal: There is no merge to abort', GitError.NoMergeToAbort],
   // GitHub-specific errors
-  'error: GH001: ': GitError.PushWithFileSizeExceedingLimit,
-  'error: GH002: ': GitError.HexBranchNameRejected,
-  'error: GH003: Sorry, force-pushing to (.+) is not allowed.': GitError.ForcePushRejected,
-  'error: GH005: Sorry, refs longer than (.+) bytes are not allowed': GitError.InvalidRefLength,
-  'error: GH006: Protected branch update failed for (.+)\nremote: error: At least one approved review is required':
-    GitError.ProtectedBranchRequiresReview,
-  'error: GH006: Protected branch update failed for (.+)\nremote: error: Cannot force-push to a protected branch':
-    GitError.ProtectedBranchForcePush,
-  'error: GH006: Protected branch update failed for (.+)\nremote: error: Cannot delete a protected branch':
-    GitError.ProtectedBranchDeleteRejected,
-  'error: GH006: Protected branch update failed for (.+).\nremote: error: Required status check "(.+)" is expected':
-    GitError.ProtectedBranchRequiredStatus,
-  'error: GH007: Your push would publish a private email address.': GitError.PushWithPrivateEmail
-}
+  ['error: GH001: ', GitError.PushWithFileSizeExceedingLimit],
+  ['error: GH002: ', GitError.HexBranchNameRejected],
+  ['error: GH003: Sorry, force-pushing to (.+) is not allowed.', GitError.ForcePushRejected],
+  ['error: GH005: Sorry, refs longer than (.+) bytes are not allowed', GitError.InvalidRefLength],
+  [
+    'error: GH006: Protected branch update failed for (.+)\nremote: error: At least one approved review is required',
+    GitError.ProtectedBranchRequiresReview
+  ],
+  [
+    'error: GH006: Protected branch update failed for (.+)\nremote: error: Cannot force-push to a protected branch',
+    GitError.ProtectedBranchForcePush
+  ],
+  [
+    'error: GH006: Protected branch update failed for (.+)\nremote: error: Cannot delete a protected branch',
+    GitError.ProtectedBranchDeleteRejected
+  ],
+  [
+    'error: GH006: Protected branch update failed for (.+).\nremote: error: Required status check "(.+)" is expected',
+    GitError.ProtectedBranchRequiredStatus
+  ],
+  ['error: GH007: Your push would publish a private email address.', GitError.PushWithPrivateEmail]
+])
 
 /**
  * The error code for when git cannot be found. This most likely indicates a

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -170,3 +170,160 @@ export function parseError(stderr: string): GitError | null {
 
   return null
 }
+
+/** The git errors which can be parsed from failed git commands. */
+enum OldGitError {
+  SSHKeyAuditUnverified,
+  SSHAuthenticationFailed,
+  SSHPermissionDenied,
+  HTTPSAuthenticationFailed,
+  RemoteDisconnection,
+  HostDown,
+  RebaseConflicts,
+  MergeConflicts,
+  HTTPSRepositoryNotFound,
+  SSHRepositoryNotFound,
+  PushNotFastForward,
+  BranchDeletionFailed,
+  DefaultBranchDeletionFailed,
+  RevertConflicts,
+  EmptyRebasePatch,
+  NoMatchingRemoteBranch,
+  NothingToCommit,
+  NoSubmoduleMapping,
+  SubmoduleRepositoryDoesNotExist,
+  InvalidSubmoduleSHA,
+  LocalPermissionDenied,
+  InvalidMerge,
+  InvalidRebase,
+  NonFastForwardMergeIntoEmptyHead,
+  PatchDoesNotApply,
+  BranchAlreadyExists,
+  BadRevision,
+  NotAGitRepository,
+  CannotMergeUnrelatedHistories,
+  LFSAttributeDoesNotMatch,
+  BranchRenameFailed,
+  PathDoesNotExist,
+  InvalidObjectName,
+  OutsideRepository,
+  LockFileAlreadyExists,
+  NoMergeToAbort,
+  // GitHub-specific error codes
+  PushWithFileSizeExceedingLimit,
+  HexBranchNameRejected,
+  ForcePushRejected,
+  InvalidRefLength,
+  ProtectedBranchRequiresReview,
+  ProtectedBranchForcePush,
+  ProtectedBranchDeleteRejected,
+  ProtectedBranchRequiredStatus,
+  PushWithPrivateEmail
+}
+
+/**
+ * Support function to migrate a stored numeric error codes raised by dugite v2
+ * to their string representation.
+ *
+ * @deprecated this will be removed in `dugite` 2.1
+ *
+ * @returns the new string-backed enum, or `null` if number does not match a
+ *          known error code
+ */
+export function migrateOldErrorCode(oldErrorCode: OldGitError): GitError | null {
+  switch (oldErrorCode) {
+    case OldGitError.SSHKeyAuditUnverified:
+      return GitError.SSHKeyAuditUnverified
+    case OldGitError.SSHAuthenticationFailed:
+      return GitError.SSHAuthenticationFailed
+    case OldGitError.SSHPermissionDenied:
+      return GitError.SSHPermissionDenied
+    case OldGitError.HTTPSAuthenticationFailed:
+      return GitError.HTTPSAuthenticationFailed
+    case OldGitError.RemoteDisconnection:
+      return GitError.RemoteDisconnection
+    case OldGitError.HostDown:
+      return GitError.HostDown
+    case OldGitError.RebaseConflicts:
+      return GitError.RebaseConflicts
+    case OldGitError.MergeConflicts:
+      return GitError.MergeConflicts
+    case OldGitError.HTTPSRepositoryNotFound:
+      return GitError.HTTPSRepositoryNotFound
+    case OldGitError.SSHRepositoryNotFound:
+      return GitError.SSHRepositoryNotFound
+    case OldGitError.PushNotFastForward:
+      return GitError.PushNotFastForward
+    case OldGitError.BranchDeletionFailed:
+      return GitError.BranchDeletionFailed
+    case OldGitError.DefaultBranchDeletionFailed:
+      return GitError.DefaultBranchDeletionFailed
+    case OldGitError.RevertConflicts:
+      return GitError.RevertConflicts
+    case OldGitError.EmptyRebasePatch:
+      return GitError.EmptyRebasePatch
+    case OldGitError.NoMatchingRemoteBranch:
+      return GitError.NoMatchingRemoteBranch
+    case OldGitError.NothingToCommit:
+      return GitError.NothingToCommit
+    case OldGitError.NoSubmoduleMapping:
+      return GitError.NoSubmoduleMapping
+    case OldGitError.SubmoduleRepositoryDoesNotExist:
+      return GitError.SubmoduleRepositoryDoesNotExist
+    case OldGitError.InvalidSubmoduleSHA:
+      return GitError.InvalidSubmoduleSHA
+    case OldGitError.LocalPermissionDenied:
+      return GitError.LocalPermissionDenied
+    case OldGitError.InvalidMerge:
+      return GitError.InvalidMerge
+    case OldGitError.InvalidRebase:
+      return GitError.InvalidRebase
+    case OldGitError.NonFastForwardMergeIntoEmptyHead:
+      return GitError.NonFastForwardMergeIntoEmptyHead
+    case OldGitError.PatchDoesNotApply:
+      return GitError.PatchDoesNotApply
+    case OldGitError.BranchAlreadyExists:
+      return GitError.BranchAlreadyExists
+    case OldGitError.BadRevision:
+      return GitError.BadRevision
+    case OldGitError.NotAGitRepository:
+      return GitError.NotAGitRepository
+    case OldGitError.CannotMergeUnrelatedHistories:
+      return GitError.CannotMergeUnrelatedHistories
+    case OldGitError.LFSAttributeDoesNotMatch:
+      return GitError.LFSAttributeDoesNotMatch
+    case OldGitError.BranchRenameFailed:
+      return GitError.BranchRenameFailed
+    case OldGitError.PathDoesNotExist:
+      return GitError.PathDoesNotExist
+    case OldGitError.InvalidObjectName:
+      return GitError.InvalidObjectName
+    case OldGitError.OutsideRepository:
+      return GitError.OutsideRepository
+    case OldGitError.LockFileAlreadyExists:
+      return GitError.LockFileAlreadyExists
+    case OldGitError.NoMergeToAbort:
+      return GitError.NoMergeToAbort
+    // GitHub-specific error codes
+    case OldGitError.PushWithFileSizeExceedingLimit:
+      return GitError.PushWithFileSizeExceedingLimit
+    case OldGitError.HexBranchNameRejected:
+      return GitError.HexBranchNameRejected
+    case OldGitError.ForcePushRejected:
+      return GitError.ForcePushRejected
+    case OldGitError.InvalidRefLength:
+      return GitError.InvalidRefLength
+    case OldGitError.ProtectedBranchRequiresReview:
+      return GitError.ProtectedBranchRequiresReview
+    case OldGitError.ProtectedBranchForcePush:
+      return GitError.ProtectedBranchForcePush
+    case OldGitError.ProtectedBranchDeleteRejected:
+      return GitError.ProtectedBranchDeleteRejected
+    case OldGitError.ProtectedBranchRequiredStatus:
+      return GitError.ProtectedBranchRequiredStatus
+    case OldGitError.PushWithPrivateEmail:
+      return GitError.PushWithPrivateEmail
+    default:
+      return null
+  }
+}

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -159,3 +159,14 @@ export const GitNotFoundErrorCode = 'git-not-found-error'
 
 /** The error code for when the path to a repository doesn't exist. */
 export const RepositoryDoesNotExistErrorCode = 'repository-does-not-exist-error'
+
+/** Try to parse an error type from stderr. */
+export function parseError(stderr: string): GitError | null {
+  for (const [regex, error] of GitErrorRegexes) {
+    if (stderr.match(regex)) {
+      return error
+    }
+  }
+
+  return null
+}

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -52,147 +52,105 @@ export enum GitError {
 
 export const GitErrorRegexes = new Map<RegExp, GitError>([
   [
-    new RegExp(
-      'ERROR: ([\\s\\S]+?)\\n+\\[EPOLICYKEYAGE\\]\\n+fatal: Could not read from remote repository.'
-    ),
+    /ERROR: ([\s\S]+?)\n+\[EPOLICYKEYAGE\]\n+fatal: Could not read from remote repository./,
     GitError.SSHKeyAuditUnverified
   ],
-  [new RegExp("fatal: Authentication failed for 'https://"), GitError.HTTPSAuthenticationFailed],
-  [new RegExp('fatal: Authentication failed'), GitError.SSHAuthenticationFailed],
-  [new RegExp('fatal: Could not read from remote repository.'), GitError.SSHPermissionDenied],
-  [new RegExp('The requested URL returned error: 403'), GitError.HTTPSAuthenticationFailed],
-  [new RegExp('fatal: The remote end hung up unexpectedly'), GitError.RemoteDisconnection],
+  [/fatal: Authentication failed for 'https:\/\//, GitError.HTTPSAuthenticationFailed],
+  [/fatal: Authentication failed/, GitError.SSHAuthenticationFailed],
+  [/fatal: Could not read from remote repository./, GitError.SSHPermissionDenied],
+  [/The requested URL returned error: 403/, GitError.HTTPSAuthenticationFailed],
+  [/fatal: The remote end hung up unexpectedly/, GitError.RemoteDisconnection],
+  [/fatal: unable to access '(.+)': Failed to connect to (.+): Host is down/, GitError.HostDown],
+  [/Failed to merge in the changes./, GitError.RebaseConflicts],
   [
-    new RegExp("fatal: unable to access '(.+)': Failed to connect to (.+): Host is down"),
-    GitError.HostDown
-  ],
-  [new RegExp('Failed to merge in the changes.'), GitError.RebaseConflicts],
-  [
-    new RegExp('(Merge conflict|Automatic merge failed; fix conflicts and then commit the result)'),
+    /(Merge conflict|Automatic merge failed; fix conflicts and then commit the result)/,
     GitError.MergeConflicts
   ],
-  [new RegExp("fatal: repository '(.+)' not found"), GitError.HTTPSRepositoryNotFound],
-  [new RegExp('ERROR: Repository not found'), GitError.SSHRepositoryNotFound],
+  [/fatal: repository '(.+)' not found/, GitError.HTTPSRepositoryNotFound],
+  [/ERROR: Repository not found/, GitError.SSHRepositoryNotFound],
   [
-    new RegExp("\\((non-fast-forward|fetch first)\\)\nerror: failed to push some refs to '.*'"),
+    /\((non-fast-forward|fetch first)\)\nerror: failed to push some refs to '.*'/,
     GitError.PushNotFastForward
   ],
+  [/error: unable to delete '(.+)': remote ref does not exist/, GitError.BranchDeletionFailed],
   [
-    new RegExp("error: unable to delete '(.+)': remote ref does not exist"),
-    GitError.BranchDeletionFailed
-  ],
-  [
-    new RegExp('\\[remote rejected\\] (.+) \\(deletion of the current branch prohibited\\)'),
+    /\[remote rejected\] (.+) \(deletion of the current branch prohibited\)/,
     GitError.DefaultBranchDeletionFailed
   ],
   [
-    new RegExp(
-      "error: could not revert .*\nhint: after resolving the conflicts, mark the corrected paths\nhint: with 'git add <paths>' or 'git rm <paths>'\nhint: and commit the result with 'git commit'"
-    ),
+    /error: could not revert .*\nhint: after resolving the conflicts, mark the corrected paths\nhint: with 'git add <paths>' or 'git rm <paths>'\nhint: and commit the result with 'git commit'/,
     GitError.RevertConflicts
   ],
   [
-    new RegExp(
-      "Applying: .*\nNo changes - did you forget to use 'git add'\\?\nIf there is nothing left to stage, chances are that something else\n.*"
-    ),
+    /Applying: .*\nNo changes - did you forget to use 'git add'\?\nIf there is nothing left to stage, chances are that something else\n.*/,
     GitError.EmptyRebasePatch
   ],
   [
-    new RegExp(
-      'There are no candidates for (rebasing|merging) among the refs that you just fetched.\nGenerally this means that you provided a wildcard refspec which had no\nmatches on the remote end.'
-    ),
+    /There are no candidates for (rebasing|merging) among the refs that you just fetched.\nGenerally this means that you provided a wildcard refspec which had no\nmatches on the remote end./,
     GitError.NoMatchingRemoteBranch
   ],
-  [new RegExp('nothing to commit'), GitError.NothingToCommit],
+  [/nothing to commit/, GitError.NothingToCommit],
+  [/No submodule mapping found in .gitmodules for path '(.+)'/, GitError.NoSubmoduleMapping],
   [
-    new RegExp("No submodule mapping found in .gitmodules for path '(.+)'"),
-    GitError.NoSubmoduleMapping
-  ],
-  [
-    new RegExp(
-      "fatal: repository '(.+)' does not exist\nfatal: clone of '.+' into submodule path '(.+)' failed"
-    ),
+    /fatal: repository '(.+)' does not exist\nfatal: clone of '.+' into submodule path '(.+)' failed/,
     GitError.SubmoduleRepositoryDoesNotExist
   ],
   [
-    new RegExp(
-      "Fetched in submodule path '(.+)', but it did not contain (.+). Direct fetching of that commit failed."
-    ),
+    /Fetched in submodule path '(.+)', but it did not contain (.+). Direct fetching of that commit failed./,
     GitError.InvalidSubmoduleSHA
   ],
   [
-    new RegExp("fatal: could not create work tree dir '(.+)'.*: Permission denied"),
+    /fatal: could not create work tree dir '(.+)'.*: Permission denied/,
     GitError.LocalPermissionDenied
   ],
-  [new RegExp('merge: (.+) - not something we can merge'), GitError.InvalidMerge],
-  [new RegExp('invalid upstream (.+)'), GitError.InvalidRebase],
+  [/merge: (.+) - not something we can merge/, GitError.InvalidMerge],
+  [/invalid upstream (.+)/, GitError.InvalidRebase],
   [
-    new RegExp('fatal: Non-fast-forward commit does not make sense into an empty head'),
+    /fatal: Non-fast-forward commit does not make sense into an empty head/,
     GitError.NonFastForwardMergeIntoEmptyHead
   ],
   [
-    new RegExp('error: (.+): (patch does not apply|already exists in working directory)'),
+    /error: (.+): (patch does not apply|already exists in working directory)/,
     GitError.PatchDoesNotApply
   ],
-  [new RegExp("fatal: A branch named '(.+)' already exists."), GitError.BranchAlreadyExists],
-  [new RegExp("fatal: bad revision '(.*)'"), GitError.BadRevision],
+  [/fatal: A branch named '(.+)' already exists./, GitError.BranchAlreadyExists],
+  [/fatal: bad revision '(.*)'/, GitError.BadRevision],
   [
-    new RegExp('fatal: [Nn]ot a git repository \\(or any of the parent directories\\): (.*)'),
+    /fatal: [Nn]ot a git repository \(or any of the parent directories\): (.*)/,
     GitError.NotAGitRepository
   ],
+  [/fatal: refusing to merge unrelated histories/, GitError.CannotMergeUnrelatedHistories],
+  [/The .+ attribute should be .+ but is .+/, GitError.LFSAttributeDoesNotMatch],
+  [/fatal: Branch rename failed/, GitError.BranchRenameFailed],
+  [/fatal: Path '(.+)' does not exist .+/, GitError.PathDoesNotExist],
+  [/fatal: Invalid object name '(.+)'./, GitError.InvalidObjectName],
+  [/fatal: .+: '(.+)' is outside repository/, GitError.OutsideRepository],
   [
-    new RegExp('fatal: refusing to merge unrelated histories'),
-    GitError.CannotMergeUnrelatedHistories
-  ],
-  [new RegExp('The .+ attribute should be .+ but is .+'), GitError.LFSAttributeDoesNotMatch],
-  [new RegExp('fatal: Branch rename failed'), GitError.BranchRenameFailed],
-  [new RegExp("fatal: Path '(.+)' does not exist .+"), GitError.PathDoesNotExist],
-  [new RegExp("fatal: Invalid object name '(.+)'."), GitError.InvalidObjectName],
-  [new RegExp("fatal: .+: '(.+)' is outside repository"), GitError.OutsideRepository],
-  [
-    new RegExp('Another git process seems to be running in this repository, e.g.'),
+    /Another git process seems to be running in this repository, e.g./,
     GitError.LockFileAlreadyExists
   ],
-  [new RegExp('fatal: There is no merge to abort'), GitError.NoMergeToAbort],
-  // GitHub-specific errors
-  [new RegExp('error: GH001: '), GitError.PushWithFileSizeExceedingLimit],
-  [new RegExp('error: GH002: '), GitError.HexBranchNameRejected],
+  [/fatal: There is no merge to abort/, GitError.NoMergeToAbort],
+  [/error: GH001: /, GitError.PushWithFileSizeExceedingLimit],
+  [/error: GH002: /, GitError.HexBranchNameRejected],
+  [/error: GH003: Sorry, force-pushing to (.+) is not allowed./, GitError.ForcePushRejected],
+  [/error: GH005: Sorry, refs longer than (.+) bytes are not allowed/, GitError.InvalidRefLength],
   [
-    new RegExp('error: GH003: Sorry, force-pushing to (.+) is not allowed.'),
-    GitError.ForcePushRejected
-  ],
-  [
-    new RegExp('error: GH005: Sorry, refs longer than (.+) bytes are not allowed'),
-    GitError.InvalidRefLength
-  ],
-  [
-    new RegExp(
-      'error: GH006: Protected branch update failed for (.+)\nremote: error: At least one approved review is required'
-    ),
+    /error: GH006: Protected branch update failed for (.+)\nremote: error: At least one approved review is required/,
     GitError.ProtectedBranchRequiresReview
   ],
   [
-    new RegExp(
-      'error: GH006: Protected branch update failed for (.+)\nremote: error: Cannot force-push to a protected branch'
-    ),
+    /error: GH006: Protected branch update failed for (.+)\nremote: error: Cannot force-push to a protected branch/,
     GitError.ProtectedBranchForcePush
   ],
   [
-    new RegExp(
-      'error: GH006: Protected branch update failed for (.+)\nremote: error: Cannot delete a protected branch'
-    ),
+    /error: GH006: Protected branch update failed for (.+)\nremote: error: Cannot delete a protected branch/,
     GitError.ProtectedBranchDeleteRejected
   ],
   [
-    new RegExp(
-      'error: GH006: Protected branch update failed for (.+).\nremote: error: Required status check "(.+)" is expected'
-    ),
+    /error: GH006: Protected branch update failed for (.+).\nremote: error: Required status check "(.+)" is expected/,
     GitError.ProtectedBranchRequiredStatus
   ],
-  [
-    new RegExp('error: GH007: Your push would publish a private email address.'),
-    GitError.PushWithPrivateEmail
-  ]
+  [/error: GH007: Your push would publish a private email address./, GitError.PushWithPrivateEmail]
 ])
 
 /**

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -67,6 +67,7 @@ export const GitErrorRegexes = new Map<RegExp, GitError>([
     GitError.MergeConflicts
   ],
   [/fatal: repository '(.+)' not found/, GitError.HTTPSRepositoryNotFound],
+  [/fatal: repository '(.+)' does not exist/, GitError.HTTPSRepositoryNotFound],
   [/ERROR: Repository not found/, GitError.SSHRepositoryNotFound],
   [
     /\((non-fast-forward|fetch first)\)\nerror: failed to push some refs to '.*'/,

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -50,108 +50,149 @@ export enum GitError {
 
 /** A mapping from regexes to the git error they identify. */
 
-export const GitErrorRegexes = new Map<string, GitError>([
+export const GitErrorRegexes = new Map<RegExp, GitError>([
   [
-    'ERROR: ([\\s\\S]+?)\\n+\\[EPOLICYKEYAGE\\]\\n+fatal: Could not read from remote repository.',
+    new RegExp(
+      'ERROR: ([\\s\\S]+?)\\n+\\[EPOLICYKEYAGE\\]\\n+fatal: Could not read from remote repository.'
+    ),
     GitError.SSHKeyAuditUnverified
   ],
-  ["fatal: Authentication failed for 'https://", GitError.HTTPSAuthenticationFailed],
-  ['fatal: Authentication failed', GitError.SSHAuthenticationFailed],
-  ['fatal: Could not read from remote repository.', GitError.SSHPermissionDenied],
-  ['The requested URL returned error: 403', GitError.HTTPSAuthenticationFailed],
-  ['fatal: The remote end hung up unexpectedly', GitError.RemoteDisconnection],
-  ["fatal: unable to access '(.+)': Failed to connect to (.+): Host is down", GitError.HostDown],
-  ['Failed to merge in the changes.', GitError.RebaseConflicts],
+  [new RegExp("fatal: Authentication failed for 'https://"), GitError.HTTPSAuthenticationFailed],
+  [new RegExp('fatal: Authentication failed'), GitError.SSHAuthenticationFailed],
+  [new RegExp('fatal: Could not read from remote repository.'), GitError.SSHPermissionDenied],
+  [new RegExp('The requested URL returned error: 403'), GitError.HTTPSAuthenticationFailed],
+  [new RegExp('fatal: The remote end hung up unexpectedly'), GitError.RemoteDisconnection],
   [
-    '(Merge conflict|Automatic merge failed; fix conflicts and then commit the result)',
+    new RegExp("fatal: unable to access '(.+)': Failed to connect to (.+): Host is down"),
+    GitError.HostDown
+  ],
+  [new RegExp('Failed to merge in the changes.'), GitError.RebaseConflicts],
+  [
+    new RegExp('(Merge conflict|Automatic merge failed; fix conflicts and then commit the result)'),
     GitError.MergeConflicts
   ],
-  ["fatal: repository '(.+)' not found", GitError.HTTPSRepositoryNotFound],
-  ['ERROR: Repository not found', GitError.SSHRepositoryNotFound],
+  [new RegExp("fatal: repository '(.+)' not found"), GitError.HTTPSRepositoryNotFound],
+  [new RegExp('ERROR: Repository not found'), GitError.SSHRepositoryNotFound],
   [
-    "\\((non-fast-forward|fetch first)\\)\nerror: failed to push some refs to '.*'",
+    new RegExp("\\((non-fast-forward|fetch first)\\)\nerror: failed to push some refs to '.*'"),
     GitError.PushNotFastForward
   ],
-  ["error: unable to delete '(.+)': remote ref does not exist", GitError.BranchDeletionFailed],
   [
-    '\\[remote rejected\\] (.+) \\(deletion of the current branch prohibited\\)',
+    new RegExp("error: unable to delete '(.+)': remote ref does not exist"),
+    GitError.BranchDeletionFailed
+  ],
+  [
+    new RegExp('\\[remote rejected\\] (.+) \\(deletion of the current branch prohibited\\)'),
     GitError.DefaultBranchDeletionFailed
   ],
   [
-    "error: could not revert .*\nhint: after resolving the conflicts, mark the corrected paths\nhint: with 'git add <paths>' or 'git rm <paths>'\nhint: and commit the result with 'git commit'",
+    new RegExp(
+      "error: could not revert .*\nhint: after resolving the conflicts, mark the corrected paths\nhint: with 'git add <paths>' or 'git rm <paths>'\nhint: and commit the result with 'git commit'"
+    ),
     GitError.RevertConflicts
   ],
   [
-    "Applying: .*\nNo changes - did you forget to use 'git add'\\?\nIf there is nothing left to stage, chances are that something else\n.*",
+    new RegExp(
+      "Applying: .*\nNo changes - did you forget to use 'git add'\\?\nIf there is nothing left to stage, chances are that something else\n.*"
+    ),
     GitError.EmptyRebasePatch
   ],
   [
-    'There are no candidates for (rebasing|merging) among the refs that you just fetched.\nGenerally this means that you provided a wildcard refspec which had no\nmatches on the remote end.',
+    new RegExp(
+      'There are no candidates for (rebasing|merging) among the refs that you just fetched.\nGenerally this means that you provided a wildcard refspec which had no\nmatches on the remote end.'
+    ),
     GitError.NoMatchingRemoteBranch
   ],
-  ['nothing to commit', GitError.NothingToCommit],
-  ["No submodule mapping found in .gitmodules for path '(.+)'", GitError.NoSubmoduleMapping],
+  [new RegExp('nothing to commit'), GitError.NothingToCommit],
   [
-    "fatal: repository '(.+)' does not exist\nfatal: clone of '.+' into submodule path '(.+)' failed",
+    new RegExp("No submodule mapping found in .gitmodules for path '(.+)'"),
+    GitError.NoSubmoduleMapping
+  ],
+  [
+    new RegExp(
+      "fatal: repository '(.+)' does not exist\nfatal: clone of '.+' into submodule path '(.+)' failed"
+    ),
     GitError.SubmoduleRepositoryDoesNotExist
   ],
   [
-    "Fetched in submodule path '(.+)', but it did not contain (.+). Direct fetching of that commit failed.",
+    new RegExp(
+      "Fetched in submodule path '(.+)', but it did not contain (.+). Direct fetching of that commit failed."
+    ),
     GitError.InvalidSubmoduleSHA
   ],
   [
-    "fatal: could not create work tree dir '(.+)'.*: Permission denied",
+    new RegExp("fatal: could not create work tree dir '(.+)'.*: Permission denied"),
     GitError.LocalPermissionDenied
   ],
-  ['merge: (.+) - not something we can merge', GitError.InvalidMerge],
-  ['invalid upstream (.+)', GitError.InvalidRebase],
+  [new RegExp('merge: (.+) - not something we can merge'), GitError.InvalidMerge],
+  [new RegExp('invalid upstream (.+)'), GitError.InvalidRebase],
   [
-    'fatal: Non-fast-forward commit does not make sense into an empty head',
+    new RegExp('fatal: Non-fast-forward commit does not make sense into an empty head'),
     GitError.NonFastForwardMergeIntoEmptyHead
   ],
   [
-    'error: (.+): (patch does not apply|already exists in working directory)',
+    new RegExp('error: (.+): (patch does not apply|already exists in working directory)'),
     GitError.PatchDoesNotApply
   ],
-  ["fatal: A branch named '(.+)' already exists.", GitError.BranchAlreadyExists],
-  ["fatal: bad revision '(.*)'", GitError.BadRevision],
+  [new RegExp("fatal: A branch named '(.+)' already exists."), GitError.BranchAlreadyExists],
+  [new RegExp("fatal: bad revision '(.*)'"), GitError.BadRevision],
   [
-    'fatal: [Nn]ot a git repository \\(or any of the parent directories\\): (.*)',
+    new RegExp('fatal: [Nn]ot a git repository \\(or any of the parent directories\\): (.*)'),
     GitError.NotAGitRepository
   ],
-  ['fatal: refusing to merge unrelated histories', GitError.CannotMergeUnrelatedHistories],
-  ['The .+ attribute should be .+ but is .+', GitError.LFSAttributeDoesNotMatch],
-  ['fatal: Branch rename failed', GitError.BranchRenameFailed],
-  ["fatal: Path '(.+)' does not exist .+", GitError.PathDoesNotExist],
-  ["fatal: Invalid object name '(.+)'.", GitError.InvalidObjectName],
-  ["fatal: .+: '(.+)' is outside repository", GitError.OutsideRepository],
   [
-    'Another git process seems to be running in this repository, e.g.',
+    new RegExp('fatal: refusing to merge unrelated histories'),
+    GitError.CannotMergeUnrelatedHistories
+  ],
+  [new RegExp('The .+ attribute should be .+ but is .+'), GitError.LFSAttributeDoesNotMatch],
+  [new RegExp('fatal: Branch rename failed'), GitError.BranchRenameFailed],
+  [new RegExp("fatal: Path '(.+)' does not exist .+"), GitError.PathDoesNotExist],
+  [new RegExp("fatal: Invalid object name '(.+)'."), GitError.InvalidObjectName],
+  [new RegExp("fatal: .+: '(.+)' is outside repository"), GitError.OutsideRepository],
+  [
+    new RegExp('Another git process seems to be running in this repository, e.g.'),
     GitError.LockFileAlreadyExists
   ],
-  ['fatal: There is no merge to abort', GitError.NoMergeToAbort],
+  [new RegExp('fatal: There is no merge to abort'), GitError.NoMergeToAbort],
   // GitHub-specific errors
-  ['error: GH001: ', GitError.PushWithFileSizeExceedingLimit],
-  ['error: GH002: ', GitError.HexBranchNameRejected],
-  ['error: GH003: Sorry, force-pushing to (.+) is not allowed.', GitError.ForcePushRejected],
-  ['error: GH005: Sorry, refs longer than (.+) bytes are not allowed', GitError.InvalidRefLength],
+  [new RegExp('error: GH001: '), GitError.PushWithFileSizeExceedingLimit],
+  [new RegExp('error: GH002: '), GitError.HexBranchNameRejected],
   [
-    'error: GH006: Protected branch update failed for (.+)\nremote: error: At least one approved review is required',
+    new RegExp('error: GH003: Sorry, force-pushing to (.+) is not allowed.'),
+    GitError.ForcePushRejected
+  ],
+  [
+    new RegExp('error: GH005: Sorry, refs longer than (.+) bytes are not allowed'),
+    GitError.InvalidRefLength
+  ],
+  [
+    new RegExp(
+      'error: GH006: Protected branch update failed for (.+)\nremote: error: At least one approved review is required'
+    ),
     GitError.ProtectedBranchRequiresReview
   ],
   [
-    'error: GH006: Protected branch update failed for (.+)\nremote: error: Cannot force-push to a protected branch',
+    new RegExp(
+      'error: GH006: Protected branch update failed for (.+)\nremote: error: Cannot force-push to a protected branch'
+    ),
     GitError.ProtectedBranchForcePush
   ],
   [
-    'error: GH006: Protected branch update failed for (.+)\nremote: error: Cannot delete a protected branch',
+    new RegExp(
+      'error: GH006: Protected branch update failed for (.+)\nremote: error: Cannot delete a protected branch'
+    ),
     GitError.ProtectedBranchDeleteRejected
   ],
   [
-    'error: GH006: Protected branch update failed for (.+).\nremote: error: Required status check "(.+)" is expected',
+    new RegExp(
+      'error: GH006: Protected branch update failed for (.+).\nremote: error: Required status check "(.+)" is expected'
+    ),
     GitError.ProtectedBranchRequiredStatus
   ],
-  ['error: GH007: Your push would publish a private email address.', GitError.PushWithPrivateEmail]
+  [
+    new RegExp('error: GH007: Your push would publish a private email address.'),
+    GitError.PushWithPrivateEmail
+  ]
 ])
 
 /**

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -77,10 +77,7 @@ export const GitErrorRegexes = new Map<RegExp, GitError>([
     /\[remote rejected\] (.+) \(deletion of the current branch prohibited\)/,
     GitError.DefaultBranchDeletionFailed
   ],
-  [
-    /error: could not revert .*\nhint: after resolving the conflicts, mark the corrected paths\nhint: with 'git add <paths>' or 'git rm <paths>'\nhint: and commit the result with 'git commit'/,
-    GitError.RevertConflicts
-  ],
+  [/error: Reverting is not possible because you have unmerged files./, GitError.RevertConflicts],
   [
     /Applying: .*\nNo changes - did you forget to use 'git add'\?\nIf there is nothing left to stage, chances are that something else\n.*/,
     GitError.EmptyRebasePatch

--- a/lib/git-process.ts
+++ b/lib/git-process.ts
@@ -1,12 +1,7 @@
 import * as fs from 'fs'
 
 import { execFile, spawn, ExecOptionsWithStringEncoding } from 'child_process'
-import {
-  GitError,
-  GitErrorRegexes,
-  RepositoryDoesNotExistErrorCode,
-  GitNotFoundErrorCode
-} from './errors'
+import { RepositoryDoesNotExistErrorCode, GitNotFoundErrorCode } from './errors'
 import { ChildProcess } from 'child_process'
 
 import { setupEnvironment } from './git-environment'
@@ -235,17 +230,6 @@ export class GitProcess {
         options.processCallback(spawnedProcess)
       }
     })
-  }
-
-  /** Try to parse an error type from stderr. */
-  public static parseError(stderr: string): GitError | null {
-    for (const [regex, error] of GitErrorRegexes) {
-      if (stderr.match(regex)) {
-        return error
-      }
-    }
-
-    return null
   }
 }
 

--- a/lib/git-process.ts
+++ b/lib/git-process.ts
@@ -239,9 +239,8 @@ export class GitProcess {
 
   /** Try to parse an error type from stderr. */
   public static parseError(stderr: string): GitError | null {
-    for (const regex in GitErrorRegexes) {
+    for (const [regex, error] of GitErrorRegexes) {
       if (stderr.match(regex)) {
-        const error: GitError = (GitErrorRegexes as any)[regex]
         return error
       }
     }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,2 +1,8 @@
 export { GitProcess, IGitResult, IGitExecutionOptions } from './git-process'
-export { GitError, RepositoryDoesNotExistErrorCode, GitNotFoundErrorCode } from './errors'
+export {
+  GitError,
+  parseError,
+  migrateOldErrorCode,
+  RepositoryDoesNotExistErrorCode,
+  GitNotFoundErrorCode
+} from './errors'

--- a/test/fast/error-test.ts
+++ b/test/fast/error-test.ts
@@ -1,0 +1,220 @@
+import * as path from 'path'
+
+import {
+  parseError,
+  GitError,
+  GitErrorRegexes,
+  RepositoryDoesNotExistErrorCode
+} from '../../lib/errors'
+import { GitProcess } from '../../lib'
+
+const temp = require('temp').track()
+
+describe('errors', () => {
+  it('each error code should have its corresponding regexp', () => {
+    const difference = (left: GitError[], right: GitError[]) =>
+      left.filter(item => right.indexOf(item) === -1)
+
+    const errorCodes = new Array<GitError>()
+
+    for (const key in GitError) {
+      errorCodes.push(GitError[key] as GitError)
+    }
+
+    const regexes = [...GitErrorRegexes.values()]
+
+    const errorCodesWithoutRegex = difference(errorCodes, regexes)
+    const regexWithoutErrorCodes = difference(regexes, errorCodes)
+
+    expect(errorCodesWithoutRegex).toHaveLength(0)
+    expect(regexWithoutErrorCodes).toHaveLength(0)
+  })
+
+  it('raises error when folder does not exist', async () => {
+    const testRepoPath = path.join(temp.path(), 'desktop-does-not-exist')
+
+    let error: Error | null = null
+    try {
+      await GitProcess.exec(['show', 'HEAD'], testRepoPath)
+    } catch (e) {
+      error = e
+    }
+
+    expect(error!.message).toBe('Unable to find path to repository on disk.')
+    expect((error as any).code).toBe(RepositoryDoesNotExistErrorCode)
+  })
+
+  it('can parse errors', () => {
+    const error = parseError('fatal: Authentication failed')
+    expect(error).toBe(GitError.SSHAuthenticationFailed)
+  })
+
+  it('can parse bad revision errors', () => {
+    const error = parseError("fatal: bad revision 'beta..origin/beta'")
+    expect(error).toBe(GitError.BadRevision)
+  })
+
+  it('can parse unrelated histories error', () => {
+    const stderr = `fatal: refusing to merge unrelated histories`
+
+    const error = parseError(stderr)
+    expect(error).toBe(GitError.CannotMergeUnrelatedHistories)
+  })
+
+  it('can parse GH001 push file size error', () => {
+    const stderr = `remote: error: GH001: Large files detected. You may want to try Git Large File Storage - https://git-lfs.github.com.
+remote: error: Trace: 2bd2bfca1605d4e0847936332f1b6c07
+remote: error: See http://git.io/iEPt8g for more information.
+remote: error: File some-file.mp4 is 292.85 MB; this exceeds GitHub's file size limit of 100.00 MB
+To https://github.com/shiftkey/too-large-repository.git
+ ! [remote rejected] master -> master (pre-receive hook declined)
+error: failed to push some refs to 'https://github.com/shiftkey/too-large-repository.git'`
+
+    expect(parseError(stderr)).toBe(GitError.PushWithFileSizeExceedingLimit)
+  })
+
+  it('can parse GH002 branch name error', () => {
+    const stderr = `remote: error: GH002: Sorry, branch or tag names consisting of 40 hex characters are not allowed.
+remote: error: Invalid branch or tag name "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+To https://github.com/shiftkey/too-large-repository.git
+ ! [remote rejected] aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa (pre-receive hook declined)
+error: failed to push some refs to 'https://github.com/shiftkey/too-large-repository.git'`
+
+    expect(parseError(stderr)).toBe(GitError.HexBranchNameRejected)
+  })
+
+  it('can parse GH003 force push error', () => {
+    const stderr = `remote: error: GH003: Sorry, force-pushing to my-cool-branch is not allowed.
+To https://github.com/shiftkey/too-large-repository.git
+ ! [remote rejected]  my-cool-branch ->  my-cool-branch (pre-receive hook declined)
+error: failed to push some refs to 'https://github.com/shiftkey/too-large-repository.git'`
+
+    expect(parseError(stderr)).toBe(GitError.ForcePushRejected)
+  })
+
+  it('can parse GH005 ref length error', () => {
+    const stderr = `remote: error: GH005: Sorry, refs longer than 255 bytes are not allowed.
+To https://github.com/shiftkey/too-large-repository.git
+...`
+    // there's probably some output here missing but I couldn't trigger this locally
+    expect(parseError(stderr)).toBe(GitError.InvalidRefLength)
+  })
+
+  it('can parse GH006 protected branch push error', () => {
+    const stderr = `remote: error: GH006: Protected branch update failed for refs/heads/master.
+remote: error: At least one approved review is required
+To https://github.com/shiftkey-tester/protected-branches.git
+ ! [remote rejected] master -> master (protected branch hook declined)
+error: failed to push some refs to 'https://github.com/shiftkey-tester/protected-branches.git'`
+
+    expect(parseError(stderr)).toBe(GitError.ProtectedBranchRequiresReview)
+  })
+
+  it('can parse GH006 protected branch force push error', () => {
+    const stderr = `remote: error: GH006: Protected branch update failed for refs/heads/master.
+remote: error: Cannot force-push to a protected branch
+To https://github.com/shiftkey/too-large-repository.git
+ ! [remote rejected] master -> master (protected branch hook declined)
+error: failed to push some refs to 'https://github.com/shiftkey/too-large-repository.git'`
+
+    expect(parseError(stderr)).toBe(GitError.ProtectedBranchForcePush)
+  })
+
+  it('can parse GH006 protected branch delete error', () => {
+    const stderr = `remote: error: GH006: Protected branch update failed for refs/heads/dupe.
+remote: error: Cannot delete a protected branch
+To https://github.com/tierninho-tester/trterdgdfgdf.git
+  ! [remote rejected] dupe (protected branch hook declined)
+error: failed to push some refs to 'https://github.com/tierninho-tester/trterdgdfgdf.git'`
+
+    expect(parseError(stderr)).toBe(GitError.ProtectedBranchDeleteRejected)
+  })
+
+  it('can parse GH006 required status check error', () => {
+    const stderr = `remote: error: GH006: Protected branch update failed for refs/heads/master.
+remote: error: Required status check "continuous-integration/travis-ci" is expected.
+To https://github.com/Raul6469/EclipseMaven.git
+  ! [remote rejected] master -> master (protected branch hook declined)
+error: failed to push some refs to 'https://github.com/Raul6469/EclipseMaven.git`
+
+    expect(parseError(stderr)).toBe(GitError.ProtectedBranchRequiredStatus)
+  })
+
+  it('can parse GH007 push with private email error', () => {
+    const stderr = `remote: error: GH007: Your push would publish a private email address.
+remote: You can make your email public or disable this protection by visiting:
+remote: http://github.com/settings/emails`
+
+    expect(parseError(stderr)).toBe(GitError.PushWithPrivateEmail)
+  })
+
+  it('can parse LFS attribute does not match error', () => {
+    const stderr = `The filter.lfs.clean attribute should be "git-lfs clean -- %f" but is "git lfs clean %f"`
+    expect(parseError(stderr)).toBe(GitError.LFSAttributeDoesNotMatch)
+  })
+
+  it('can parse rename Branch error', () => {
+    const stderr = `error: refname refs/heads/adding-renamefailed-error not found
+      fatal: Branch rename failed`
+    expect(parseError(stderr)).toBe(GitError.BranchRenameFailed)
+  })
+
+  it('can parse path does not exist error - neither on disk nor in the index', () => {
+    const stderr = "fatal: Path 'missing.txt' does not exist (neither on disk nor in the index).\n"
+    expect(parseError(stderr)).toBe(GitError.PathDoesNotExist)
+  })
+
+  it('can parse path does not exist error - in commitish', () => {
+    const stderr = "fatal: Path 'missing.txt' does not exist in 'HEAD'\n"
+    expect(parseError(stderr)).toBe(GitError.PathDoesNotExist)
+  })
+
+  it('can parse invalid object name error', () => {
+    const stderr = "fatal: Invalid object name 'HEAD'.\n"
+    expect(parseError(stderr)).toBe(GitError.InvalidObjectName)
+  })
+
+  it('can parse revert failed error', () => {
+    const stderr = `error: Reverting is not possible because you have unmerged files.
+hint: Fix them up in the work tree, and then use 'git add/rm <file>',
+as appropriate, to mark resolution and make a commit.
+fatal: revert failed`
+    expect(parseError(stderr)).toBe(GitError.RevertConflicts)
+  })
+
+  it('can parse repository not found error', () => {
+    const stderr = `fatal: repository 'gsgdgsgdsgsgsgdsgds' does not exist`
+    expect(parseError(stderr)).toBe(GitError.HTTPSRepositoryNotFound)
+  })
+
+  it('can parse is outside repository error', () => {
+    const stderr = "fatal: /missing.txt: '/missing.txt' is outside repository\n"
+    expect(parseError(stderr)).toBe(GitError.OutsideRepository)
+  })
+
+  it('can parse lock file exists error', () => {
+    const stderr = `Unable to create  'path_to_repo/.git/index.lock: File exists.
+
+Another git process seems to be running in this repository, e.g.
+an editor opened by 'git commit'. Please make sure all processes
+are terminated then try again. If it still fails, a git process
+may have crashed in this repository earlier:
+remove the file manually to continue.`
+    expect(parseError(stderr)).toBe(GitError.LockFileAlreadyExists)
+  })
+
+  it('can parse the previous not found repository error', () => {
+    const stderr = 'fatal: Not a git repository (or any of the parent directories): .git'
+    expect(parseError(stderr)).toBe(GitError.NotAGitRepository)
+  })
+
+  it('can parse the current found repository error', () => {
+    const stderr = 'fatal: not a git repository (or any of the parent directories): .git'
+    expect(parseError(stderr)).toBe(GitError.NotAGitRepository)
+  })
+
+  it('can parse the no merge to abort error', () => {
+    const stderr = 'fatal: There is no merge to abort (MERGE_HEAD missing).\n'
+    expect(parseError(stderr)).toBe(GitError.NoMergeToAbort)
+  })
+})

--- a/test/fast/git-process-test.ts
+++ b/test/fast/git-process-test.ts
@@ -356,6 +356,16 @@ remote: http://github.com/settings/emails`
       expect(error).toBe(GitError.InvalidObjectName)
     })
 
+    it('can parse revert failed error', () => {
+      const stderr = `error: Reverting is not possible because you have unmerged files.
+hint: Fix them up in the work tree, and then use 'git add/rm <file>',
+as appropriate, to mark resolution and make a commit.
+fatal: revert failed`
+
+      const error = GitProcess.parseError(stderr)
+      expect(error).toBe(GitError.RevertConflicts)
+    })
+
     it('can parse is outside repository error', () => {
       const stderr = "fatal: /missing.txt: '/missing.txt' is outside repository\n"
 

--- a/test/fast/git-process-test.ts
+++ b/test/fast/git-process-test.ts
@@ -2,8 +2,8 @@ import * as path from 'path'
 import * as fs from 'fs'
 import * as crypto from 'crypto'
 
-import { GitProcess, GitError, RepositoryDoesNotExistErrorCode } from '../../lib'
-import { GitErrorRegexes } from '../../lib/errors'
+import { GitProcess, GitError } from '../../lib'
+import { parseError } from '../../lib/errors'
 import { initialize, verify } from '../helpers'
 
 import { gitVersion } from '../helpers'
@@ -123,12 +123,13 @@ describe('git-process', () => {
           expect(r.stdout.trim()).toBe('some content')
         })
       })
+
       it('missing from index', async () => {
         const testRepoPath = await initialize('desktop-show-missing-index')
 
         const result = await GitProcess.exec(['show', ':missing.txt'], testRepoPath)
         verify(result, r => {
-          expect(GitProcess.parseError(r.stderr)).toBe(GitError.PathDoesNotExist)
+          expect(parseError(r.stderr)).toBe(GitError.PathDoesNotExist)
         })
       })
       it('missing from commitish', async () => {
@@ -143,7 +144,7 @@ describe('git-process', () => {
 
         const result = await GitProcess.exec(['show', 'HEAD:missing.txt'], testRepoPath)
         verify(result, r => {
-          expect(GitProcess.parseError(r.stderr)).toBe(GitError.PathDoesNotExist)
+          expect(parseError(r.stderr)).toBe(GitError.PathDoesNotExist)
         })
       })
       it('invalid object name - empty repository', async () => {
@@ -151,7 +152,7 @@ describe('git-process', () => {
 
         const result = await GitProcess.exec(['show', 'HEAD:missing.txt'], testRepoPath)
         verify(result, r => {
-          expect(GitProcess.parseError(r.stderr)).toBe(GitError.InvalidObjectName)
+          expect(parseError(r.stderr)).toBe(GitError.InvalidObjectName)
         })
       })
       it('outside repository', async () => {
@@ -166,252 +167,9 @@ describe('git-process', () => {
 
         const result = await GitProcess.exec(['show', '--', '/missing.txt'], testRepoPath)
         verify(result, r => {
-          expect(GitProcess.parseError(r.stderr)).toBe(GitError.OutsideRepository)
+          expect(parseError(r.stderr)).toBe(GitError.OutsideRepository)
         })
       })
-    })
-  })
-
-  describe('errors', () => {
-    it('each error code should have its corresponding regexp', () => {
-      const difference = (left: GitError[], right: GitError[]) =>
-        left.filter(item => right.indexOf(item) === -1)
-
-      const errorCodes = new Array<GitError>()
-
-      for (const key in GitError) {
-        errorCodes.push(GitError[key] as GitError)
-      }
-
-      const regexes = [...GitErrorRegexes.values()]
-
-      const errorCodesWithoutRegex = difference(errorCodes, regexes)
-      const regexWithoutErrorCodes = difference(regexes, errorCodes)
-
-      expect(errorCodesWithoutRegex).toHaveLength(0)
-      expect(regexWithoutErrorCodes).toHaveLength(0)
-    })
-
-    it('raises error when folder does not exist', async () => {
-      const testRepoPath = path.join(temp.path(), 'desktop-does-not-exist')
-
-      let error: Error | null = null
-      try {
-        await GitProcess.exec(['show', 'HEAD'], testRepoPath)
-      } catch (e) {
-        error = e
-      }
-
-      expect(error!.message).toBe('Unable to find path to repository on disk.')
-      expect((error as any).code).toBe(RepositoryDoesNotExistErrorCode)
-    })
-
-    it('can parse errors', () => {
-      const error = GitProcess.parseError('fatal: Authentication failed')
-      expect(error).toBe(GitError.SSHAuthenticationFailed)
-    })
-
-    it('can parse bad revision errors', () => {
-      const error = GitProcess.parseError("fatal: bad revision 'beta..origin/beta'")
-      expect(error).toBe(GitError.BadRevision)
-    })
-
-    it('can parse unrelated histories error', () => {
-      const stderr = `fatal: refusing to merge unrelated histories`
-
-      const error = GitProcess.parseError(stderr)
-      expect(error).toBe(GitError.CannotMergeUnrelatedHistories)
-    })
-
-    it('can parse GH001 push file size error', () => {
-      const stderr = `remote: error: GH001: Large files detected. You may want to try Git Large File Storage - https://git-lfs.github.com.
-remote: error: Trace: 2bd2bfca1605d4e0847936332f1b6c07
-remote: error: See http://git.io/iEPt8g for more information.
-remote: error: File some-file.mp4 is 292.85 MB; this exceeds GitHub's file size limit of 100.00 MB
-To https://github.com/shiftkey/too-large-repository.git
- ! [remote rejected] master -> master (pre-receive hook declined)
-error: failed to push some refs to 'https://github.com/shiftkey/too-large-repository.git'`
-
-      const error = GitProcess.parseError(stderr)
-      expect(error).toBe(GitError.PushWithFileSizeExceedingLimit)
-    })
-
-    it('can parse GH002 branch name error', () => {
-      const stderr = `remote: error: GH002: Sorry, branch or tag names consisting of 40 hex characters are not allowed.
-remote: error: Invalid branch or tag name "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-To https://github.com/shiftkey/too-large-repository.git
- ! [remote rejected] aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa -> aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa (pre-receive hook declined)
-error: failed to push some refs to 'https://github.com/shiftkey/too-large-repository.git'`
-
-      const error = GitProcess.parseError(stderr)
-      expect(error).toBe(GitError.HexBranchNameRejected)
-    })
-
-    it('can parse GH003 force push error', () => {
-      const stderr = `remote: error: GH003: Sorry, force-pushing to my-cool-branch is not allowed.
-To https://github.com/shiftkey/too-large-repository.git
- ! [remote rejected]  my-cool-branch ->  my-cool-branch (pre-receive hook declined)
-error: failed to push some refs to 'https://github.com/shiftkey/too-large-repository.git'`
-
-      const error = GitProcess.parseError(stderr)
-      expect(error).toBe(GitError.ForcePushRejected)
-    })
-
-    it('can parse GH005 ref length error', () => {
-      const stderr = `remote: error: GH005: Sorry, refs longer than 255 bytes are not allowed.
-To https://github.com/shiftkey/too-large-repository.git
-...`
-      // there's probably some output here missing but I couldn't trigger this locally
-
-      const error = GitProcess.parseError(stderr)
-      expect(error).toBe(GitError.InvalidRefLength)
-    })
-
-    it('can parse GH006 protected branch push error', () => {
-      const stderr = `remote: error: GH006: Protected branch update failed for refs/heads/master.
-remote: error: At least one approved review is required
-To https://github.com/shiftkey-tester/protected-branches.git
- ! [remote rejected] master -> master (protected branch hook declined)
-error: failed to push some refs to 'https://github.com/shiftkey-tester/protected-branches.git'`
-      const error = GitProcess.parseError(stderr)
-      expect(error).toBe(GitError.ProtectedBranchRequiresReview)
-    })
-
-    it('can parse GH006 protected branch force push error', () => {
-      const stderr = `remote: error: GH006: Protected branch update failed for refs/heads/master.
-remote: error: Cannot force-push to a protected branch
-To https://github.com/shiftkey/too-large-repository.git
- ! [remote rejected] master -> master (protected branch hook declined)
-error: failed to push some refs to 'https://github.com/shiftkey/too-large-repository.git'`
-
-      const error = GitProcess.parseError(stderr)
-      expect(error).toBe(GitError.ProtectedBranchForcePush)
-    })
-
-    it('can parse GH006 protected branch delete error', () => {
-      const stderr = `remote: error: GH006: Protected branch update failed for refs/heads/dupe.
-remote: error: Cannot delete a protected branch
-To https://github.com/tierninho-tester/trterdgdfgdf.git
-  ! [remote rejected] dupe (protected branch hook declined)
-error: failed to push some refs to 'https://github.com/tierninho-tester/trterdgdfgdf.git'`
-
-      const error = GitProcess.parseError(stderr)
-      expect(error).toBe(GitError.ProtectedBranchDeleteRejected)
-    })
-
-    it('can parse GH006 required status check error', () => {
-      const stderr = `remote: error: GH006: Protected branch update failed for refs/heads/master.
-remote: error: Required status check "continuous-integration/travis-ci" is expected.
-To https://github.com/Raul6469/EclipseMaven.git
-  ! [remote rejected] master -> master (protected branch hook declined)
-error: failed to push some refs to 'https://github.com/Raul6469/EclipseMaven.git`
-
-      const error = GitProcess.parseError(stderr)
-      expect(error).toBe(GitError.ProtectedBranchRequiredStatus)
-    })
-
-    it('can parse GH007 push with private email error', () => {
-      const stderr = `remote: error: GH007: Your push would publish a private email address.
-remote: You can make your email public or disable this protection by visiting:
-remote: http://github.com/settings/emails`
-
-      const error = GitProcess.parseError(stderr)
-      expect(error).toBe(GitError.PushWithPrivateEmail)
-    })
-
-    it('can parse LFS attribute does not match error', () => {
-      const stderr = `The filter.lfs.clean attribute should be "git-lfs clean -- %f" but is "git lfs clean %f"`
-
-      const error = GitProcess.parseError(stderr)
-      expect(error).toBe(GitError.LFSAttributeDoesNotMatch)
-    })
-
-    it('can parse rename Branch error', () => {
-      const stderr = `error: refname refs/heads/adding-renamefailed-error not found
-      fatal: Branch rename failed`
-
-      const error = GitProcess.parseError(stderr)
-      expect(error).toBe(GitError.BranchRenameFailed)
-    })
-
-    it('can parse path does not exist error - neither on disk nor in the index', () => {
-      const stderr =
-        "fatal: Path 'missing.txt' does not exist (neither on disk nor in the index).\n"
-
-      const error = GitProcess.parseError(stderr)
-      expect(error).toBe(GitError.PathDoesNotExist)
-    })
-
-    it('can parse path does not exist error - in commitish', () => {
-      const stderr = "fatal: Path 'missing.txt' does not exist in 'HEAD'\n"
-
-      const error = GitProcess.parseError(stderr)
-      expect(error).toBe(GitError.PathDoesNotExist)
-    })
-
-    it('can parse invalid object name error', () => {
-      const stderr = "fatal: Invalid object name 'HEAD'.\n"
-
-      const error = GitProcess.parseError(stderr)
-      expect(error).toBe(GitError.InvalidObjectName)
-    })
-
-    it('can parse revert failed error', () => {
-      const stderr = `error: Reverting is not possible because you have unmerged files.
-hint: Fix them up in the work tree, and then use 'git add/rm <file>',
-as appropriate, to mark resolution and make a commit.
-fatal: revert failed`
-
-      const error = GitProcess.parseError(stderr)
-      expect(error).toBe(GitError.RevertConflicts)
-    })
-
-    it('can parse repository not found error', () => {
-      const stderr = `fatal: repository 'gsgdgsgdsgsgsgdsgds' does not exist`
-
-      const error = GitProcess.parseError(stderr)
-      expect(error).toBe(GitError.HTTPSRepositoryNotFound)
-    })
-
-    it('can parse is outside repository error', () => {
-      const stderr = "fatal: /missing.txt: '/missing.txt' is outside repository\n"
-
-      const error = GitProcess.parseError(stderr)
-      expect(error).toBe(GitError.OutsideRepository)
-    })
-
-    it('can parse lock file exists error', () => {
-      const stderr = `Unable to create  'path_to_repo/.git/index.lock: File exists.
-
-Another git process seems to be running in this repository, e.g.
-an editor opened by 'git commit'. Please make sure all processes
-are terminated then try again. If it still fails, a git process
-may have crashed in this repository earlier:
-remove the file manually to continue.`
-
-      const error = GitProcess.parseError(stderr)
-      expect(error).toBe(GitError.LockFileAlreadyExists)
-    })
-
-    it('can parse the previous not found repository error', () => {
-      const stderr = 'fatal: Not a git repository (or any of the parent directories): .git'
-
-      const error = GitProcess.parseError(stderr)
-      expect(error).toBe(GitError.NotAGitRepository)
-    })
-
-    it('can parse the current found repository error', () => {
-      const stderr = 'fatal: not a git repository (or any of the parent directories): .git'
-
-      const error = GitProcess.parseError(stderr)
-      expect(error).toBe(GitError.NotAGitRepository)
-    })
-
-    it('can parse the no merge to abort error', () => {
-      const stderr = 'fatal: There is no merge to abort (MERGE_HEAD missing).\n'
-
-      const error = GitProcess.parseError(stderr)
-      expect(error).toBe(GitError.NoMergeToAbort)
     })
   })
 })

--- a/test/fast/git-process-test.ts
+++ b/test/fast/git-process-test.ts
@@ -177,7 +177,12 @@ describe('git-process', () => {
       const difference = (left: GitError[], right: GitError[]) =>
         left.filter(item => right.indexOf(item) === -1)
 
-      const errorCodes = Object.keys(GitError).map((key: keyof typeof GitError) => GitError[key])
+      const errorCodes = new Array<GitError>()
+
+      for (const key in GitError) {
+        errorCodes.push(GitError[key] as GitError)
+      }
+
       const regexes = [...GitErrorRegexes.values()]
 
       const errorCodesWithoutRegex = difference(errorCodes, regexes)

--- a/test/fast/git-process-test.ts
+++ b/test/fast/git-process-test.ts
@@ -177,8 +177,8 @@ describe('git-process', () => {
       const difference = (left: GitError[], right: GitError[]) =>
         left.filter(item => right.indexOf(item) === -1)
 
-      const errorCodes = Object.keys(GitError).map(key => (GitError as any)[key] as GitError)
-      const regexes = new Array<GitError>(...GitErrorRegexes.values())
+      const errorCodes = Object.keys(GitError).map((key: keyof typeof GitError) => GitError[key])
+      const regexes = [...GitErrorRegexes.values()]
 
       const errorCodesWithoutRegex = difference(errorCodes, regexes)
       const regexWithoutErrorCodes = difference(regexes, errorCodes)

--- a/test/fast/git-process-test.ts
+++ b/test/fast/git-process-test.ts
@@ -174,12 +174,11 @@ describe('git-process', () => {
 
   describe('errors', () => {
     it('each error code should have its corresponding regexp', () => {
-      const difference = (left: number[], right: number[]) =>
+      const difference = (left: GitError[], right: GitError[]) =>
         left.filter(item => right.indexOf(item) === -1)
-      const errorCodes = Object.keys(GitError)
-        .map(key => (GitError as any)[key])
-        .filter(ordinal => Number.isInteger(ordinal))
-      const regexes = Object.keys(GitErrorRegexes).map(key => (GitErrorRegexes as any)[key])
+
+      const errorCodes = Object.keys(GitError).map(key => (GitError as any)[key] as GitError)
+      const regexes = new Array<GitError>(...GitErrorRegexes.values())
 
       const errorCodesWithoutRegex = difference(errorCodes, regexes)
       const regexWithoutErrorCodes = difference(regexes, errorCodes)

--- a/test/fast/git-process-test.ts
+++ b/test/fast/git-process-test.ts
@@ -366,6 +366,13 @@ fatal: revert failed`
       expect(error).toBe(GitError.RevertConflicts)
     })
 
+    it('can parse repository not found error', () => {
+      const stderr = `fatal: repository 'gsgdgsgdsgsgsgdsgds' does not exist`
+
+      const error = GitProcess.parseError(stderr)
+      expect(error).toBe(GitError.HTTPSRepositoryNotFound)
+    })
+
     it('can parse is outside repository error', () => {
       const stderr = "fatal: /missing.txt: '/missing.txt' is outside repository\n"
 

--- a/test/slow/git-process-test.ts
+++ b/test/slow/git-process-test.ts
@@ -1,7 +1,7 @@
 import * as Fs from 'fs'
 import * as Path from 'path'
 
-import { GitProcess, GitError } from '../../lib'
+import { GitProcess, GitError, parseError } from '../../lib'
 import { initialize, verify } from '../helpers'
 import { setupAskPass, setupNoAuth } from './auth'
 
@@ -46,7 +46,7 @@ describe('git-process', () => {
       verify(result, r => {
         expect(r.exitCode).toBe(128)
       })
-      const error = GitProcess.parseError(result.stderr)
+      const error = parseError(result.stderr)
       expect(error).toBe(GitError.HTTPSAuthenticationFailed)
     })
 
@@ -111,7 +111,7 @@ describe('git-process', () => {
       verify(result, r => {
         expect(r.exitCode).toBe(128)
       })
-      const error = GitProcess.parseError(result.stderr)
+      const error = parseError(result.stderr)
       expect(error).toBe(GitError.HTTPSAuthenticationFailed)
     })
 


### PR DESCRIPTION
This PR makes the original `GitError` enum (which is backed by numbers) into a string enum that uses a human-friendly string as the backing store.

This is annoying for scenarios where you're testing the error code raised:

```shellsession
 FAIL  test/fast/git-process-test.ts
  ● git-process › errors › can parse the no merge to abort error

    expect(received).toBe(expected) // Object.is equality

    Expected: 8
    Received: 35

      391 |
      392 |       const error = GitProcess.parseError(stderr)
    > 393 |       expect(error).toBe(GitError.HTTPSRepositoryNotFound)
          |                     ^
      394 |     })
      395 |   })
      396 | })

      at Object.it (test/fast/git-process-test.ts:393:21)
```

What's the actual value I receive here? You need to literally count the number of entries in `GitError` to get to the 35th one:

<img width="368" src="https://user-images.githubusercontent.com/359239/48718779-6a219980-ebf2-11e8-9ad1-0fcf8947c382.png">

With this change, it becomes infinitely easier to understand:

```shellsession
 FAIL  test/fast/git-process-test.ts
  ● git-process › errors › can parse the no merge to abort error

    expect(received).toBe(expected) // Object.is equality

    Expected: "https-repository-not-found"
    Received: "no-merge-to-abort"

      390 |
      391 |       const error = GitProcess.parseError(stderr)
    > 392 |       expect(error).toBe(GitError.HTTPSRepositoryNotFound)
          |                     ^
      393 |     })
      394 |   })
      395 | })

      at Object.it (test/fast/git-process-test.ts:392:21)
```

Unfortunately this is a breaking change to the public API (`GitProcess.parseError` returns `GitError | null`), so I'll plan to bump `dugite` to a v2 once this change is merged. I also plan to write a migration guide using GitHub Desktop as an example (it uses this error parsing heavily) as part of this process.

Meanwhile I'm also going to fix a couple of related error parsing bugs:

 - Fixes #156
 - Fixes #155 

TODO:

 - [x] update API to return string enum
 - [x] write migration guide