### PR TITLE
Error Case for Pulling Non-Existent Branch

### DIFF
--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -16,6 +16,7 @@ export enum GitError {
   RevertConflicts,
   EmptyRebasePatch,
   NoMatchingRemoteBranch,
+  NoExistingRemoteBranch,
   NothingToCommit,
   NoSubmoduleMapping,
   SubmoduleRepositoryDoesNotExist,
@@ -74,6 +75,8 @@ export const GitErrorRegexes = {
     GitError.EmptyRebasePatch,
   'There are no candidates for (rebasing|merging) among the refs that you just fetched.\nGenerally this means that you provided a wildcard refspec which had no\nmatches on the remote end.':
     GitError.NoMatchingRemoteBranch,
+  "Your configuration specifies to merge with the ref '(.+)' from the remote, but no such ref was fetched.":
+    GitError.NoExistingRemoteBranch,
   'nothing to commit': GitError.NothingToCommit,
   "No submodule mapping found in .gitmodules for path '(.+)'": GitError.NoSubmoduleMapping,
   "fatal: repository '(.+)' does not exist\nfatal: clone of '.+' into submodule path '(.+)' failed":

--- a/test/fast/git-process-test.ts
+++ b/test/fast/git-process-test.ts
@@ -392,5 +392,13 @@ remove the file manually to continue.`
       const error = GitProcess.parseError(stderr)
       expect(error).toBe(GitError.NoMergeToAbort)
     })
+
+    it('can parse the pulling non-existent remote branch error', () => {
+      const stderr =
+        "Your configuration specifies to merge with the ref 'refs/heads/tierninho-patch-1' from the remote, but no such ref was fetched.\n"
+
+      const error = GitProcess.parseError(stderr)
+      expect(error).toBe(GitError.NoExistingRemoteBranch)
+    })
   })
 })


### PR DESCRIPTION
Capture errors similar to:
`Your configuration specifies to merge with the ref 'refs/heads/tierninho-patch-1' from the remote, but no such ref was fetched.`

Addresses: https://github.com/desktop/desktop/issues/1325.

Planning to address this GHD side as well, later. 

This is my first contribution to Dugite so apologies if ordering is a bit off.