### PR TITLE
migrate test config to use new key

### DIFF
--- a/jest.external.config.js
+++ b/jest.external.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   roots: ['<rootDir>/lib/', '<rootDir>/test/'],
   testMatch: ['**/test/external/**/*-test.ts'],
-  setupTestFrameworkScriptFile: '<rootDir>/test/slow-setup.ts',
+  setupFilesAfterEnv: ['<rootDir>/test/slow-setup.ts'],
   collectCoverageFrom: ['lib/**/*.{js,ts}', '!**/node_modules/**', '!**/index.ts'],
   coverageReporters: ['text-summary', 'json'],
   globals: {

--- a/jest.fast.config.js
+++ b/jest.fast.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   roots: ['<rootDir>/lib/', '<rootDir>/test/'],
   testMatch: ['**/test/fast/**/*-test.ts'],
-  setupTestFrameworkScriptFile: '<rootDir>/test/fast-setup.ts',
+  setupFilesAfterEnv: ['<rootDir>/test/fast-setup.ts'],
   collectCoverageFrom: ['lib/**/*.{js,ts}', '!**/node_modules/**', '!**/index.ts'],
   coverageReporters: ['text-summary', 'json'],
   globals: {

--- a/jest.slow.config.js
+++ b/jest.slow.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   roots: ['<rootDir>/lib/', '<rootDir>/test/'],
   testMatch: ['**/test/slow/**/*-test.ts'],
-  setupTestFrameworkScriptFile: '<rootDir>/test/slow-setup.ts',
+  setupFilesAfterEnv: ['<rootDir>/test/slow-setup.ts'],
   collectCoverageFrom: ['lib/**/*.{js,ts}', '!**/node_modules/**', '!**/index.ts'],
   coverageReporters: ['text-summary', 'json'],
   globals: {


### PR DESCRIPTION
This warning is emitted whenever your run any of the tests:

```
● Deprecation Warning:

  Option "setupTestFrameworkScriptFile" was replaced by configuration "setupFilesAfterEnv", which supports multiple paths.

  Please update your configuration.

  Configuration Documentation:
  https://jestjs.io/docs/configuration.html
```