### PR TITLE
add error code for UnresolvedConflicts

### DIFF
--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -38,6 +38,7 @@ export enum GitError {
   LockFileAlreadyExists,
   NoMergeToAbort,
   LocalChangesOverwritten,
+  UnresolvedConflicts,
   // GitHub-specific error codes
   PushWithFileSizeExceedingLimit,
   HexBranchNameRejected,
@@ -107,6 +108,8 @@ export const GitErrorRegexes = {
   'fatal: There is no merge to abort': GitError.NoMergeToAbort,
   'error: (?:Your local changes to the following|The following untracked working tree) files would be overwritten by checkout:':
     GitError.LocalChangesOverwritten,
+  'You must edit all merge conflicts and then\nmark them as resolved using git add':
+    GitError.UnresolvedConflicts,
   // GitHub-specific errors
   'error: GH001: ': GitError.PushWithFileSizeExceedingLimit,
   'error: GH002: ': GitError.HexBranchNameRejected,

--- a/test/fast/git-process-test.ts
+++ b/test/fast/git-process-test.ts
@@ -414,5 +414,14 @@ remove the file manually to continue.`
       error = GitProcess.parseError(stderr)
       expect(error).toBe(GitError.LocalChangesOverwritten)
     })
+
+    it('can parse the unresovled conflicts error', () => {
+      const stderr = `2-simple-rebase-conflict/LICENSE.md: needs merge
+You must edit all merge conflicts and then
+mark them as resolved using git add`
+
+      const error = GitProcess.parseError(stderr)
+      expect(error).toBe(GitError.UnresolvedConflicts)
+    })
   })
 })


### PR DESCRIPTION
If you are in a rebase or merge and have conflicts to resolve, this error is raised when there are unmerged files and you try to continue to complete the rebase/merge.

This feels more reliable than looking for exit code `1`:

```
$ git rebase --continue
2-simple-rebase-conflict/LICENSE.md: needs merge
You must edit all merge conflicts and then
mark them as resolved using git add
$ echo $?
1
```