### PR TITLE
Add additional regex pattern for HostDown error code

### DIFF
--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -61,7 +61,7 @@ export const GitErrorRegexes = {
   'The requested URL returned error: 403': GitError.HTTPSAuthenticationFailed,
   'fatal: The remote end hung up unexpectedly': GitError.RemoteDisconnection,
   "fatal: unable to access '(.+)': Failed to connect to (.+): Host is down": GitError.HostDown,
-  "Cloning into '(.+)'...↵fatal: unable to access '(.+)': Could not resolve host: (.+)↵":
+  "Cloning into '(.+)'...\nfatal: unable to access '(.+)': Could not resolve host: (.+)\n":
     GitError.HostDown,
   'Failed to merge in the changes.': GitError.RebaseConflicts,
   '(Merge conflict|Automatic merge failed; fix conflicts and then commit the result)':

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -61,7 +61,7 @@ export const GitErrorRegexes = {
   'The requested URL returned error: 403': GitError.HTTPSAuthenticationFailed,
   'fatal: The remote end hung up unexpectedly': GitError.RemoteDisconnection,
   "fatal: unable to access '(.+)': Failed to connect to (.+): Host is down": GitError.HostDown,
-  "Cloning into '(.+)'...\nfatal: unable to access '(.+)': Could not resolve host: (.+)\n":
+  "Cloning into '(.+)'...\nfatal: unable to access '(.+)': Could not resolve host: (.+)":
     GitError.HostDown,
   'Failed to merge in the changes.': GitError.RebaseConflicts,
   '(Merge conflict|Automatic merge failed; fix conflicts and then commit the result)':

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -61,6 +61,8 @@ export const GitErrorRegexes = {
   'The requested URL returned error: 403': GitError.HTTPSAuthenticationFailed,
   'fatal: The remote end hung up unexpectedly': GitError.RemoteDisconnection,
   "fatal: unable to access '(.+)': Failed to connect to (.+): Host is down": GitError.HostDown,
+  "Cloning into '(.+)'... fatal: unable to access '(.+)': Could not resolve host: (.+)":
+    GitError.HostDown,
   'Failed to merge in the changes.': GitError.RebaseConflicts,
   '(Merge conflict|Automatic merge failed; fix conflicts and then commit the result)':
     GitError.MergeConflicts,

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -61,7 +61,7 @@ export const GitErrorRegexes = {
   'The requested URL returned error: 403': GitError.HTTPSAuthenticationFailed,
   'fatal: The remote end hung up unexpectedly': GitError.RemoteDisconnection,
   "fatal: unable to access '(.+)': Failed to connect to (.+): Host is down": GitError.HostDown,
-  "Cloning into '(.+)'... fatal: unable to access '(.+)': Could not resolve host: (.+)":
+  "Cloning into '(.+)'...↵fatal: unable to access '(.+)': Could not resolve host: (.+)↵":
     GitError.HostDown,
   'Failed to merge in the changes.': GitError.RebaseConflicts,
   '(Merge conflict|Automatic merge failed; fix conflicts and then commit the result)':

--- a/test/fast/git-process-test.ts
+++ b/test/fast/git-process-test.ts
@@ -423,5 +423,12 @@ mark them as resolved using git add`
       const error = GitProcess.parseError(stderr)
       expect(error).toBe(GitError.UnresolvedConflicts)
     })
+
+    it('can parse the could not resolve host error', () => {
+      const stderr = `"Cloning into '/cloneablepath/'... fatal: unable to access 'https://github.com/Daniel-McCarthy/dugite.git/': Could not resolve host: github.com"`
+
+      const error = GitProcess.parseError(stderr)
+      expect(error).toBe(GitError.HostDown)
+    })
   })
 })

--- a/test/fast/git-process-test.ts
+++ b/test/fast/git-process-test.ts
@@ -425,7 +425,7 @@ mark them as resolved using git add`
     })
 
     it('can parse the could not resolve host error', () => {
-      const stderr = `"Cloning into '/cloneablepath/'...↵fatal: unable to access 'https://github.com/Daniel-McCarthy/dugite.git/': Could not resolve host: github.com↵"`
+      const stderr = `"Cloning into '/cloneablepath/'...\nfatal: unable to access 'https://github.com/Daniel-McCarthy/dugite.git/': Could not resolve host: github.com\n"`
 
       const error = GitProcess.parseError(stderr)
       expect(error).toBe(GitError.HostDown)

--- a/test/fast/git-process-test.ts
+++ b/test/fast/git-process-test.ts
@@ -425,7 +425,7 @@ mark them as resolved using git add`
     })
 
     it('can parse the could not resolve host error', () => {
-      const stderr = `"Cloning into '/cloneablepath/'... fatal: unable to access 'https://github.com/Daniel-McCarthy/dugite.git/': Could not resolve host: github.com"`
+      const stderr = `"Cloning into '/cloneablepath/'...↵fatal: unable to access 'https://github.com/Daniel-McCarthy/dugite.git/': Could not resolve host: github.com↵"`
 
       const error = GitProcess.parseError(stderr)
       expect(error).toBe(GitError.HostDown)


### PR DESCRIPTION
This pull request is made to assist Desktop's [Issue #926](https://github.com/desktop/desktop/issues/926) by adding a regex pattern to detect a cloning failure error. Currently the error is not being parsed due to not having a pattern that matches to it. The error in question occurs when attempting to clone a repository with no available internet connection.

The exact error to be detected is: 
`"Cloning into '/home/hellokitty/Documents/GitHub/Chixel'... fatal: unable to access 'https://github.com/Daniel-McCarthy/Chixel.git/': Could not resolve host: github.com"`
___
In [a comment](https://github.com/desktop/desktop/issues/926#issuecomment-468799999) it was suggested that this regular expression pattern should be added to target the same error type `HostDown` that is being used by a currently existing regex pattern. I have added a test to go along with checking the new regular expression pattern is parsing properly. However, I noticed there was not already one in place for the original `HostDown` error regex. I could add a test to go along with the original pattern as well in this pull request.


