### PR TITLE
handle "dirty index" error when pull with rebase fails

### DIFF
--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -39,6 +39,7 @@ export enum GitError {
   NoMergeToAbort,
   LocalChangesOverwritten,
   UnresolvedConflicts,
+  DirtyIndexCannotApplyPatches,
   // GitHub-specific error codes
   PushWithFileSizeExceedingLimit,
   HexBranchNameRejected,
@@ -112,6 +113,7 @@ export const GitErrorRegexes = {
     GitError.LocalChangesOverwritten,
   'You must edit all merge conflicts and then\nmark them as resolved using git add':
     GitError.UnresolvedConflicts,
+  'fatal: Dirty index: cannot apply patches': GitError.DirtyIndexCannotApplyPatches,
   // GitHub-specific errors
   'error: GH001: ': GitError.PushWithFileSizeExceedingLimit,
   'error: GH002: ': GitError.HexBranchNameRejected,

--- a/test/fast/git-process-test.ts
+++ b/test/fast/git-process-test.ts
@@ -430,5 +430,12 @@ mark them as resolved using git add`
       const error = GitProcess.parseError(stderr)
       expect(error).toBe(GitError.HostDown)
     })
+
+    it('can parse dirty index error', () => {
+      const stderr = `fatal: Dirty index: cannot apply patches (dirty: .DS_Store TestWebAppProject/Controllers/HomeController.cs sdfsd)`
+
+      const error = GitProcess.parseError(stderr)
+      expect(error).toBe(GitError.DirtyIndexCannotApplyPatches)
+    })
   })
 })


### PR DESCRIPTION
This was uncovered in https://github.com/desktop/desktop/issues/7103 and to summarize the problem:

 -  a `git pull` with `pull.rebase` is run
 - local commits are encountered, which need to be rebased on top of the commits from the tracking branch
 - inside `rebase.c` we encounter a code path that needs to run `git am` as a child process:

https://github.com/git/git/blob/0e94f7aa730b108f7907cfab1b2a7fba965de442/builtin/rebase.c#L731-L734

```c
	if (opts->type == REBASE_AM) {
		status = run_am(opts);
		goto finished_rebase;
	}
```

This eventually ends up here, and between starting the `pull` with rebase something has modified the index:

https://github.com/git/git/blob/6e0cc6776106079ed4efa0cc9abace4107657abf/builtin/am.c#L1709-L1712

```c
	if (repo_index_has_changes(the_repository, NULL, &sb)) {
		write_state_bool(state, "dirtyindex", 1);
		die(_("Dirty index: cannot apply patches (dirty: %s)"), sb.buf);
	}
```