### PR TITLE
Add ability to configure architecture to download proper Git binary

### DIFF
--- a/script/config.js
+++ b/script/config.js
@@ -14,7 +14,8 @@ function getConfig() {
     tempFile: ''
   }
 
-  const key = `${process.platform}-${os.arch()}`
+  const targetArch = process.env.DUGITE_DOWNLOAD_ARCH || os.arch()
+  const key = `${process.platform}-${targetArch}`
 
   const entry = embeddedGit[key]
 

--- a/script/embedded-git.json
+++ b/script/embedded-git.json
@@ -9,6 +9,11 @@
     "url": "https://github.com/desktop/dugite-native/releases/download/v2.21.0/dugite-native-v2.21.0-954b7fe-windows-x86.tar.gz",
     "checksum": "79183f337de97ff01cfaff5f12bbe6201a08ba63802c01f74c524128eeca7a4f"
   },
+  "win32-arm64": {
+    "name": "dugite-native-v2.21.0-954b7fe-windows-x86.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.21.0/dugite-native-v2.21.0-954b7fe-windows-x86.tar.gz",
+    "checksum": "79183f337de97ff01cfaff5f12bbe6201a08ba63802c01f74c524128eeca7a4f"
+  },
   "darwin-x64": {
     "name": "dugite-native-v2.21.0-954b7fe-macOS.tar.gz",
     "url": "https://github.com/desktop/dugite-native/releases/download/v2.21.0/dugite-native-v2.21.0-954b7fe-macOS.tar.gz",

--- a/script/update-embedded-git.js
+++ b/script/update-embedded-git.js
@@ -21,6 +21,7 @@ got(url, options).then(
     const output = {
       'win32-x64': await findWindows64BitRelease(assets),
       'win32-ia32': await findWindows32BitRelease(assets),
+      'win32-arm64': await findWindows32BitRelease(assets),
       'darwin-x64': await findMacOS64BitRelease(assets),
       'linux-x64': await findLinux64BitRelease(assets),
       'linux-arm64': await findLinuxARM64Release(assets)


### PR DESCRIPTION
The main motivation is to support Dugite module on Windows on ARM64.
Since Git for Windows is not available on this architecture yet,
but Windows 10 allows x86 code to run on the ARM64 version of Windows 10.
We should download 'win32-ia32' binary in this case. Sometimes it would be
nice if the architecture could be configurable.

For example Electron relies on Dugite module. To build Electron
for Windows on ARM64 we use Windows x64 host machine. So during the npm install,
the Dugite script downloads x64 git binary based on host arch. However
that is not compatible with WoA. It needs to force to download x86 binary in this case.