### PR TITLE
Don't assume there's a standard input stream

### DIFF
--- a/lib/git-process.ts
+++ b/lib/git-process.ts
@@ -278,6 +278,13 @@ export class GitProcess {
  * See https://github.com/desktop/desktop/pull/4027#issuecomment-366213276
  */
 function ignoreClosedInputStream(process: ChildProcess) {
+  // If Node fails to spawn due to a runtime error (EACCESS, EAGAIN, etc)
+  // it will not setup the stdio streams, see
+  // https://github.com/nodejs/node/blob/v10.16.0/lib/internal/child_process.js#L342-L354
+  // The error itself will be emitted asynchronously but we're still in
+  // the synchronous path so if we attempts to call `.on` on `.stdin`
+  // (which is undefined) that error would be thrown before the underlying
+  // error.
   if (!process.stdin) {
     return
   }

--- a/lib/git-process.ts
+++ b/lib/git-process.ts
@@ -278,6 +278,9 @@ export class GitProcess {
  * See https://github.com/desktop/desktop/pull/4027#issuecomment-366213276
  */
 function ignoreClosedInputStream(process: ChildProcess) {
+  if (!process.stdin) {
+    return
+  }
   process.stdin.on('error', err => {
     const code = (err as ErrorWithCode).code
 


### PR DESCRIPTION
In https://github.com/desktop/dugite/pull/164 I added this function (`ignoreClosedInputStream `) to stop Node from throwing uncatchable asynchronous errors. It's served us well but recently I discovered another edge case where it's possible for an instance of `ChildProcess` returned from `spawn` to not have `stdin`, `stdout`, or `stderr` initialized.

The problem is perhaps most plainly described with this example

```js
> require('child_process').spawn('/dev/null').stdout
undefined
> Thrown:
{ Error: spawn /dev/null EACCES
    at Process.ChildProcess._handle.onexit (internal/child_process.js:240:19)
    at onErrorNT (internal/child_process.js:415:16)
    at process._tickCallback (internal/process/next_tick.js:63:19)
  errno: 'EACCES',
  code: 'EACCES',
  syscall: 'spawn /dev/null',
  path: '/dev/null',
  spawnargs: [],
...
```

The `spawn` call returns a valid instance of `ChildProcess` but the `stdout` property is undefined. The actual error gets emitted asynchronously.

What this all means is that the dugite `spawn` and `exec` function will end up throwing a synchronous `TypeError` (`Cannot read property 'on' of undefined`) before the actual underlying error can get propagated through the process `error` event to the consumer.