### PR TITLE
Release 1.88.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dugite",
-  "version": "1.88.0-beta.0",
+  "version": "1.88.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dugite",
-  "version": "1.88.0-beta.0",
+  "version": "1.88.0",
   "description": "Elegant bindings for Git",
   "main": "./build/lib/index.js",
   "typings": "./build/lib/index.d.ts",

--- a/script/embedded-git.json
+++ b/script/embedded-git.json
@@ -1,27 +1,22 @@
 {
   "win32-x64": {
-    "name": "dugite-native-v2.21.0-954b7fe-windows-x64.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.21.0/dugite-native-v2.21.0-954b7fe-windows-x64.tar.gz",
-    "checksum": "ca4f201bbaef0936d3f5aabbcf44dd3b42afd50c1362a5f2e543bfd2501a1e8a"
+    "name": "dugite-native-v2.23.1-98a1094-windows-x64.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.23.1/dugite-native-v2.23.1-98a1094-windows-x64.tar.gz",
+    "checksum": "9dd6b0c9e3cc355b67c667010795bea8b0f47d262e156f36c58d5313039b0c98"
   },
   "win32-ia32": {
-    "name": "dugite-native-v2.21.0-954b7fe-windows-x86.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.21.0/dugite-native-v2.21.0-954b7fe-windows-x86.tar.gz",
-    "checksum": "79183f337de97ff01cfaff5f12bbe6201a08ba63802c01f74c524128eeca7a4f"
+    "name": "dugite-native-v2.23.1-98a1094-windows-x86.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.23.1/dugite-native-v2.23.1-98a1094-windows-x86.tar.gz",
+    "checksum": "77bd6ab5a931788ab951aa2fdfc16e064e89d7a38a3ace7ce7068a4c3dd64ef3"
   },
   "darwin-x64": {
-    "name": "dugite-native-v2.21.0-954b7fe-macOS.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.21.0/dugite-native-v2.21.0-954b7fe-macOS.tar.gz",
-    "checksum": "507a543a390045a6be1c372cf1b23eec1384d9f4f1db7337c39cd1cf638c1e2e"
+    "name": "dugite-native-v2.23.1-98a1094-macOS.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.23.1/dugite-native-v2.23.1-98a1094-macOS.tar.gz",
+    "checksum": "f3fb4e514f31d83988a2ff3251ac5c09b5db89981f6f86a6b1b719d700ba09af"
   },
   "linux-x64": {
-    "name": "dugite-native-v2.21.0-954b7fe-ubuntu.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.21.0/dugite-native-v2.21.0-954b7fe-ubuntu.tar.gz",
-    "checksum": "662436cf45a343a5181a4784af5a8b2c6999bac4be4729b6b87c913d151e89ff"
-  },
-  "linux-arm64": {
-    "name": "dugite-native-v2.21.0-954b7fe-arm64.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.21.0/dugite-native-v2.21.0-954b7fe-arm64.tar.gz",
-    "checksum": "82038d454cc09ef324f91af744cb1cb43786808990b0f80f893a4d3bc3286dd3"
+    "name": "dugite-native-v2.23.1-98a1094-ubuntu.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.23.1/dugite-native-v2.23.1-98a1094-ubuntu.tar.gz",
+    "checksum": "38a90c8bb5a75ec983a194a0d0bb40a8ed560c12691da916650f3d644f0234b3"
   }
 }

--- a/script/embedded-git.json
+++ b/script/embedded-git.json
@@ -1,22 +1,22 @@
 {
   "win32-x64": {
-    "name": "dugite-native-v2.23.1-98a1094-windows-x64.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.23.1/dugite-native-v2.23.1-98a1094-windows-x64.tar.gz",
-    "checksum": "9dd6b0c9e3cc355b67c667010795bea8b0f47d262e156f36c58d5313039b0c98"
+    "name": "dugite-native-v2.23.1-a050c16-windows-x64.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.23.1/dugite-native-v2.23.1-a050c16-windows-x64.tar.gz",
+    "checksum": "c4d20ddbb3b3432d7ef455c28d8687e6a11b80fe95a0711eecee195741be63e0"
   },
   "win32-ia32": {
-    "name": "dugite-native-v2.23.1-98a1094-windows-x86.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.23.1/dugite-native-v2.23.1-98a1094-windows-x86.tar.gz",
-    "checksum": "77bd6ab5a931788ab951aa2fdfc16e064e89d7a38a3ace7ce7068a4c3dd64ef3"
+    "name": "dugite-native-v2.23.1-a050c16-windows-x86.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.23.1/dugite-native-v2.23.1-a050c16-windows-x86.tar.gz",
+    "checksum": "2591b699e29fad603567109fbc13b10dadc5ece57c9fa6f5505a7b5c6dd1121d"
   },
   "darwin-x64": {
-    "name": "dugite-native-v2.23.1-98a1094-macOS.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.23.1/dugite-native-v2.23.1-98a1094-macOS.tar.gz",
-    "checksum": "f3fb4e514f31d83988a2ff3251ac5c09b5db89981f6f86a6b1b719d700ba09af"
+    "name": "dugite-native-v2.23.1-a050c16-macOS.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.23.1/dugite-native-v2.23.1-a050c16-macOS.tar.gz",
+    "checksum": "347d9ff1f3564c0fed31e3de72899d7e0289324f85ff4bc9e8348222ff2f9dcd"
   },
   "linux-x64": {
-    "name": "dugite-native-v2.23.1-98a1094-ubuntu.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.23.1/dugite-native-v2.23.1-98a1094-ubuntu.tar.gz",
-    "checksum": "38a90c8bb5a75ec983a194a0d0bb40a8ed560c12691da916650f3d644f0234b3"
+    "name": "dugite-native-v2.23.1-a050c16-ubuntu.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.23.1/dugite-native-v2.23.1-a050c16-ubuntu.tar.gz",
+    "checksum": "a2f229b1c0cb60550ca77c2f35de86a402267700a24d2fa3fcebd2b23409b5a5"
   }
 }

--- a/script/update-embedded-git.js
+++ b/script/update-embedded-git.js
@@ -22,8 +22,7 @@ got(url, options).then(
       'win32-x64': await findWindows64BitRelease(assets),
       'win32-ia32': await findWindows32BitRelease(assets),
       'darwin-x64': await findMacOS64BitRelease(assets),
-      'linux-x64': await findLinux64BitRelease(assets),
-      'linux-arm64': await findLinuxARM64Release(assets)
+      'linux-x64': await findLinux64BitRelease(assets)
     }
 
     const fileContents = JSON.stringify(output, null, 2)
@@ -72,14 +71,6 @@ function findLinux64BitRelease(assets) {
   const asset = assets.find(a => a.name.endsWith('-ubuntu.tar.gz'))
   if (asset == null) {
     throw new Error('Could not find Linux 64-bit archive in latest release')
-  }
-  return getDetailsForAsset(assets, asset)
-}
-
-function findLinuxARM64Release(assets) {
-  const asset = assets.find(a => a.name.endsWith('-arm64.tar.gz'))
-  if (asset == null) {
-    throw new Error('Could not find Linux ARM64 archive in latest release')
   }
   return getDetailsForAsset(assets, asset)
 }

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,8 +1,8 @@
 import { GitProcess, IGitResult } from '../lib'
 
 // NOTE: bump these versions to the latest stable releases
-export const gitVersion = '2.21.0'
-export const gitLfsVersion = '2.6.1'
+export const gitVersion = '2.23.'
+export const gitLfsVersion = '2.7.2'
 
 const temp = require('temp').track()
 


### PR DESCRIPTION
Includes https://github.com/desktop/dugite-native/pull/316 and drops support for ARM64 (https://github.com/desktop/dugite-native/pull/315)


### TODO

- [x] npm version minor
- [x] npm publish
- [x] push the tag