### PR TITLE
Add "remote already exists" error parsing

### DIFF
--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -49,7 +49,8 @@ export enum GitError {
   ProtectedBranchDeleteRejected,
   ProtectedBranchRequiredStatus,
   PushWithPrivateEmail,
-  ConfigLockFileAlreadyExists
+  ConfigLockFileAlreadyExists,
+  RemoteAlreadyExists
 }
 
 /** A mapping from regexes to the git error they identify. */
@@ -127,7 +128,8 @@ export const GitErrorRegexes = {
   'error: GH006: Protected branch update failed for (.+).\nremote: error: Required status check "(.+)" is expected':
     GitError.ProtectedBranchRequiredStatus,
   'error: GH007: Your push would publish a private email address.': GitError.PushWithPrivateEmail,
-  'error: could not lock config file (.+): File exists': GitError.ConfigLockFileAlreadyExists
+  'error: could not lock config file (.+): File exists': GitError.ConfigLockFileAlreadyExists,
+  'fatal: remote (.+) already exists.': GitError.RemoteAlreadyExists
 }
 
 /**

--- a/test/fast/errors-test.ts
+++ b/test/fast/errors-test.ts
@@ -1,0 +1,19 @@
+import { GitProcess, GitError } from '../../lib'
+import { verify, initialize } from '../helpers'
+
+describe('detects errors', () => {
+  it('RemoteAlreadyExists', async () => {
+    const repoPath = await initialize('remote-already-exists-test-repo')
+
+    await GitProcess.exec(['remote', 'add', 'new-remote', 'https://github.com'], repoPath)
+
+    const result = await GitProcess.exec(
+      ['remote', 'add', 'new-remote', 'https://gitlab.com'],
+      repoPath
+    )
+
+    verify(result, r => {
+      expect(GitProcess.parseError(r.stderr)).toBe(GitError.RemoteAlreadyExists)
+    })
+  })
+})


### PR DESCRIPTION
_Supports https://github.com/desktop/desktop/issues/9048. Once this is approved and merged, I will do a `1.88.1` release of dugite with only this addition._

This adds error parsing for an error encountered when you try to add a remote with a name that already exists.

I've also added a test to ensure that this error is detected in the right case.