### PR TITLE
Detect unstashed files errors

### DIFF
--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -52,7 +52,9 @@ export enum GitError {
   // End of GitHub-specific error codes
   ConfigLockFileAlreadyExists,
   RemoteAlreadyExists,
-  TagAlreadyExists
+  TagAlreadyExists,
+  MergeWithLocalChanges,
+  RebaseWithLocalChanges
 }
 
 /** A mapping from regexes to the git error they identify. */
@@ -132,7 +134,11 @@ export const GitErrorRegexes: { [regexp: string]: GitError } = {
   'error: GH007: Your push would publish a private email address.': GitError.PushWithPrivateEmail,
   'error: could not lock config file (.+): File exists': GitError.ConfigLockFileAlreadyExists,
   'fatal: remote (.+) already exists.': GitError.RemoteAlreadyExists,
-  "fatal: tag '(.+)' already exists": GitError.TagAlreadyExists
+  "fatal: tag '(.+)' already exists": GitError.TagAlreadyExists,
+  'error: Your local changes to the following files would be overwritten by merge:\n':
+    GitError.MergeWithLocalChanges,
+  'error: cannot (pull with rebase|rebase): You have unstaged changes\\.\n\\s*error: [Pp]lease commit or stash them\\.':
+    GitError.RebaseWithLocalChanges
 }
 
 /**

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -55,7 +55,7 @@ export enum GitError {
 }
 
 /** A mapping from regexes to the git error they identify. */
-export const GitErrorRegexes = {
+export const GitErrorRegexes: { [regexp: string]: GitError } = {
   'ERROR: ([\\s\\S]+?)\\n+\\[EPOLICYKEYAGE\\]\\n+fatal: Could not read from remote repository.':
     GitError.SSHKeyAuditUnverified,
   "fatal: Authentication failed for 'https://": GitError.HTTPSAuthenticationFailed,

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -39,7 +39,7 @@ export enum GitError {
   NoMergeToAbort,
   LocalChangesOverwritten,
   UnresolvedConflicts,
-  // GitHub-specific error codes
+  // Start of GitHub-specific error codes
   PushWithFileSizeExceedingLimit,
   HexBranchNameRejected,
   ForcePushRejected,
@@ -49,6 +49,7 @@ export enum GitError {
   ProtectedBranchDeleteRejected,
   ProtectedBranchRequiredStatus,
   PushWithPrivateEmail,
+  // End of GitHub-specific error codes
   ConfigLockFileAlreadyExists,
   RemoteAlreadyExists,
   TagAlreadyExists

--- a/lib/git-process.ts
+++ b/lib/git-process.ts
@@ -239,9 +239,8 @@ export class GitProcess {
 
   /** Try to parse an error type from stderr. */
   public static parseError(stderr: string): GitError | null {
-    for (const regex in GitErrorRegexes) {
+    for (const [regex, error] of Object.entries(GitErrorRegexes)) {
       if (stderr.match(regex)) {
-        const error: GitError = (GitErrorRegexes as any)[regex]
         return error
       }
     }

--- a/test/fast/git-process-test.ts
+++ b/test/fast/git-process-test.ts
@@ -4,7 +4,7 @@ import * as crypto from 'crypto'
 
 import { GitProcess, GitError, RepositoryDoesNotExistErrorCode } from '../../lib'
 import { GitErrorRegexes } from '../../lib/errors'
-import { initialize, verify } from '../helpers'
+import { initialize, verify, initializeWithRemote } from '../helpers'
 
 import { gitVersion } from '../helpers'
 
@@ -479,6 +479,84 @@ mark them as resolved using git add`
 
       // Execute a rebase.
       const result = await GitProcess.exec(['rebase', 'some-other-branch'], repoPath)
+
+      verify(result, r => {
+        expect(GitProcess.parseError(r.stderr)).toBe(GitError.RebaseWithLocalChanges)
+      })
+    })
+
+    it('can parse an error when pulling with merge with local changes', async () => {
+      const { path: repoPath, remote: remoteRepositoryPath } = await initializeWithRemote(
+        'desktop-pullrebase-with-local-changes',
+        null
+      )
+      const { path: forkRepoPath } = await initializeWithRemote(
+        'desktop-pullrebase-with-local-changes-fork',
+        remoteRepositoryPath
+      )
+      await GitProcess.exec(['config', 'pull.rebase', 'false'], forkRepoPath)
+      const readmePath = path.join(repoPath, 'Readme.md')
+      const readmePathInFork = path.join(forkRepoPath, 'Readme.md')
+
+      // Add a commit to the default branch.
+      fs.writeFileSync(readmePath, '# README', { encoding: 'utf8' })
+      await GitProcess.exec(['add', '.'], repoPath)
+      await GitProcess.exec(['commit', '-m', '"added README"'], repoPath)
+
+      // Push the commit and fetch it from the fork.
+      await GitProcess.exec(['push', 'origin', 'HEAD', '-u'], repoPath)
+      await GitProcess.exec(['pull', 'origin', 'HEAD'], forkRepoPath)
+
+      // Add another commit and push it
+      fs.writeFileSync(readmePath, '# README modified from upstream', { encoding: 'utf8' })
+      await GitProcess.exec(['add', '.'], repoPath)
+      await GitProcess.exec(['commit', '-m', '"updated README"'], repoPath)
+      await GitProcess.exec(['push', 'origin'], repoPath)
+
+      // Modify locally the Readme file in the fork.
+      fs.writeFileSync(readmePathInFork, '# README modified from fork', { encoding: 'utf8' })
+
+      // Pull from the fork
+      const result = await GitProcess.exec(['pull', 'origin', 'HEAD'], forkRepoPath)
+
+      verify(result, r => {
+        expect(GitProcess.parseError(r.stderr)).toBe(GitError.MergeWithLocalChanges)
+      })
+    })
+
+    it('can parse an error when pulling with rebase with local changes', async () => {
+      const { path: repoPath, remote: remoteRepositoryPath } = await initializeWithRemote(
+        'desktop-pullrebase-with-local-changes',
+        null
+      )
+      const { path: forkRepoPath } = await initializeWithRemote(
+        'desktop-pullrebase-with-local-changes-fork',
+        remoteRepositoryPath
+      )
+      await GitProcess.exec(['config', 'pull.rebase', 'true'], forkRepoPath)
+      const readmePath = path.join(repoPath, 'Readme.md')
+      const readmePathInFork = path.join(forkRepoPath, 'Readme.md')
+
+      // Add a commit to the default branch.
+      fs.writeFileSync(readmePath, '# README', { encoding: 'utf8' })
+      await GitProcess.exec(['add', '.'], repoPath)
+      await GitProcess.exec(['commit', '-m', '"added README"'], repoPath)
+
+      // Push the commit and fetch it from the fork.
+      await GitProcess.exec(['push', 'origin', 'HEAD', '-u'], repoPath)
+      await GitProcess.exec(['pull', 'origin', 'HEAD'], forkRepoPath)
+
+      // Add another commit and push it
+      fs.writeFileSync(readmePath, '# README modified from upstream', { encoding: 'utf8' })
+      await GitProcess.exec(['add', '.'], repoPath)
+      await GitProcess.exec(['commit', '-m', '"updated README"'], repoPath)
+      await GitProcess.exec(['push', 'origin'], repoPath)
+
+      // Modify locally the Readme file in the fork.
+      fs.writeFileSync(readmePathInFork, '# README modified from fork', { encoding: 'utf8' })
+
+      // Pull from the fork
+      const result = await GitProcess.exec(['pull', 'origin', 'HEAD'], forkRepoPath)
 
       verify(result, r => {
         expect(GitProcess.parseError(r.stderr)).toBe(GitError.RebaseWithLocalChanges)

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -18,8 +18,8 @@ export async function initialize(repositoryName: string): Promise<string> {
  * Initialize a repository with a remote pointing to a local bare repository.
  * If the remotePath is not specified, the remote repository will get automatically created.
  *
- * @param repositoryName
- * @param remotePath
+ * @param repositoryName    The name of the repository to create
+ * @param remotePath        The path of the remote reposiry (when null a new repository will get created)
  */
 export async function initializeWithRemote(
   repositoryName: string,

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -14,6 +14,33 @@ export async function initialize(repositoryName: string): Promise<string> {
   return testRepoPath
 }
 
+/**
+ * Initialize a repository with a remote pointing to a local bare repository.
+ * If the remotePath is not specified, the remote repository will get automatically created.
+ *
+ * @param repositoryName
+ * @param remotePath
+ */
+export async function initializeWithRemote(
+  repositoryName: string,
+  remotePath: string | null
+): Promise<{ path: string; remote: string }> {
+  if (remotePath === null) {
+    const path = temp.mkdirSync(`desktop-git-test-remote-${repositoryName}`)
+    await GitProcess.exec(['init', '--bare'], path)
+    remotePath = path
+  }
+
+  if (remotePath === null) {
+    throw new Error('for TypeScript')
+  }
+
+  const testRepoPath = await initialize(repositoryName)
+  await GitProcess.exec(['remote', 'add', 'origin', remotePath], testRepoPath)
+
+  return { path: testRepoPath, remote: remotePath }
+}
+
 export function verify(result: IGitResult, callback: (result: IGitResult) => void) {
   try {
     callback(result)


### PR DESCRIPTION
This PR adds the detection of two new type of errors to `dugite`:

* `MergeWithLocalChanges`, which will get returned whenever the user tries to do a merge operation with a local change that will get overriden by the merge.
* `RebaseWithLocalChanges`, which will get returned under the same conditions but when rebasing.

Note that these two errors can be returned both when explicitly executing a merge/rebase (via `git merge`/`git rebase`) or whenever the user pulls from a remote (if the user has the `pull.rebase` config option to true, they will get the rebase error, otherwise they will get the merge one).

These new detections will be used along with the existing `LocalChangesOverwritten` error to offer users the possibility of stashing their changes when one of the errors gets returned by git (see https://github.com/desktop/desktop/issues/8197#issuecomment-619524546 for more information)