### PR TITLE
Add toHaveGitError() custom matcher for tests

### DIFF
--- a/test/fast/errors-test.ts
+++ b/test/fast/errors-test.ts
@@ -1,5 +1,5 @@
 import { GitProcess, GitError } from '../../lib'
-import { verify, initialize } from '../helpers'
+import { initialize } from '../helpers'
 import { writeFileSync } from 'fs'
 import { join } from 'path'
 
@@ -14,9 +14,7 @@ describe('detects errors', () => {
       repoPath
     )
 
-    verify(result, r => {
-      expect(GitProcess.parseError(r.stderr)).toBe(GitError.RemoteAlreadyExists)
-    })
+    expect(result).toHaveGitError(GitError.RemoteAlreadyExists)
   })
   it('TagAlreadyExists', async () => {
     const repoPath = await initialize('tag-already-exists-test-repo')
@@ -31,6 +29,6 @@ describe('detects errors', () => {
     // try to make the same tag again
     const result = await GitProcess.exec(['tag', 'v0.1'], repoPath)
 
-    expect(GitProcess.parseError(result.stderr)).toBe(GitError.TagAlreadyExists)
+    expect(result).toHaveGitError(GitError.TagAlreadyExists)
   })
 })

--- a/test/fast/git-process-test.ts
+++ b/test/fast/git-process-test.ts
@@ -127,9 +127,8 @@ describe('git-process', () => {
         const testRepoPath = await initialize('desktop-show-missing-index')
 
         const result = await GitProcess.exec(['show', ':missing.txt'], testRepoPath)
-        verify(result, r => {
-          expect(GitProcess.parseError(r.stderr)).toBe(GitError.PathDoesNotExist)
-        })
+
+        expect(result).toHaveGitError(GitError.PathDoesNotExist)
       })
       it('missing from commitish', async () => {
         const testRepoPath = await initialize('desktop-show-missing-commitish')
@@ -142,17 +141,15 @@ describe('git-process', () => {
         await GitProcess.exec(['commit', '-m', '"added a file"'], testRepoPath)
 
         const result = await GitProcess.exec(['show', 'HEAD:missing.txt'], testRepoPath)
-        verify(result, r => {
-          expect(GitProcess.parseError(r.stderr)).toBe(GitError.PathDoesNotExist)
-        })
+
+        expect(result).toHaveGitError(GitError.PathDoesNotExist)
       })
       it('invalid object name - empty repository', async () => {
         const testRepoPath = await initialize('desktop-show-invalid-object-empty')
 
         const result = await GitProcess.exec(['show', 'HEAD:missing.txt'], testRepoPath)
-        verify(result, r => {
-          expect(GitProcess.parseError(r.stderr)).toBe(GitError.InvalidObjectName)
-        })
+
+        expect(result).toHaveGitError(GitError.InvalidObjectName)
       })
       it('outside repository', async () => {
         const testRepoPath = await initialize('desktop-show-outside')
@@ -165,9 +162,8 @@ describe('git-process', () => {
         await GitProcess.exec(['commit', '-m', '"added a file"'], testRepoPath)
 
         const result = await GitProcess.exec(['show', '--', '/missing.txt'], testRepoPath)
-        verify(result, r => {
-          expect(GitProcess.parseError(r.stderr)).toBe(GitError.OutsideRepository)
-        })
+
+        expect(result).toHaveGitError(GitError.OutsideRepository)
       })
     })
   })
@@ -453,9 +449,7 @@ mark them as resolved using git add`
       // Execute a merge.
       const result = await GitProcess.exec(['merge', 'some-other-branch'], repoPath)
 
-      verify(result, r => {
-        expect(GitProcess.parseError(r.stderr)).toBe(GitError.MergeWithLocalChanges)
-      })
+      expect(result).toHaveGitError(GitError.MergeWithLocalChanges)
     })
 
     it('can parse an error when renasing with local changes', async () => {
@@ -480,9 +474,7 @@ mark them as resolved using git add`
       // Execute a rebase.
       const result = await GitProcess.exec(['rebase', 'some-other-branch'], repoPath)
 
-      verify(result, r => {
-        expect(GitProcess.parseError(r.stderr)).toBe(GitError.RebaseWithLocalChanges)
-      })
+      expect(result).toHaveGitError(GitError.RebaseWithLocalChanges)
     })
 
     it('can parse an error when pulling with merge with local changes', async () => {
@@ -519,9 +511,7 @@ mark them as resolved using git add`
       // Pull from the fork
       const result = await GitProcess.exec(['pull', 'origin', 'HEAD'], forkRepoPath)
 
-      verify(result, r => {
-        expect(GitProcess.parseError(r.stderr)).toBe(GitError.MergeWithLocalChanges)
-      })
+      expect(result).toHaveGitError(GitError.MergeWithLocalChanges)
     })
 
     it('can parse an error when pulling with rebase with local changes', async () => {
@@ -558,9 +548,7 @@ mark them as resolved using git add`
       // Pull from the fork
       const result = await GitProcess.exec(['pull', 'origin', 'HEAD'], forkRepoPath)
 
-      verify(result, r => {
-        expect(GitProcess.parseError(r.stderr)).toBe(GitError.RebaseWithLocalChanges)
-      })
+      expect(result).toHaveGitError(GitError.RebaseWithLocalChanges)
     })
   })
 })

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,4 +1,4 @@
-import { GitProcess, IGitResult } from '../lib'
+import { GitProcess, IGitResult, GitError } from '../lib'
 
 // NOTE: bump these versions to the latest stable releases
 export const gitVersion = '2.26.'
@@ -51,5 +51,62 @@ export function verify(result: IGitResult, callback: (result: IGitResult) => voi
     console.log(` - stderr: ${result.stderr.trim()}`)
     console.log()
     throw e
+  }
+}
+
+/**
+ * Reverse maps the provided GitError to print a friendly name for debugging tests.
+ *
+ * @param gitError GitError
+ */
+function getFriendlyGitError(gitError: GitError): string {
+  const found = Object.entries(GitError).find(([key, value]) => {
+    return value === gitError
+  })
+
+  if (found === undefined) {
+    return gitError.toString()
+  }
+
+  return found[0]
+}
+
+expect.extend({
+  toHaveGitError(result: IGitResult, expectedError: GitError) {
+    let gitError = GitProcess.parseError(result.stderr)
+    if (gitError === null) {
+      gitError = GitProcess.parseError(result.stdout)
+    }
+
+    const message = () => {
+      return [
+        this.utils.matcherHint(`${this.isNot ? '.not' : ''}.toHaveGitError`, 'result', 'gitError'),
+        '',
+        'Expected',
+        `  ${this.utils.printExpected(getFriendlyGitError(expectedError))}`,
+        'Received:',
+        `  ${this.utils.printReceived(gitError ? getFriendlyGitError(gitError) : null)}`
+      ].join('\n')
+    }
+
+    if (gitError === expectedError) {
+      return {
+        pass: true,
+        message
+      }
+    }
+
+    return {
+      pass: false,
+      message
+    }
+  }
+})
+
+declare global {
+  namespace jest {
+    interface Matchers<R = IGitResult> {
+      toHaveGitError(result: GitError): CustomMatcherResult
+    }
   }
 }


### PR DESCRIPTION
This PR adds a `toHaveGitError()` custom matcher that allows to check if a `result` object from `Dugite` contains the expected error.

This has 3 benefits compared to the current solution:

1. It mimics the logic [found in `desktop`](https://github.com/desktop/desktop/blob/development/app/src/lib/git/core.ts#L156-L159) to parse the error, by first trying to parse it using `stderr` and afterwards use `stdout` (no more having to juggle between the two in the tests).
2. The call it's a little bit more concise/readable on the tests.
3. The error message can be tweaked to be much easier to read (I've reverse-mapped the git errors to show a more legible message):

Before:

```
    expect(received).toBe(expected) // Object.is equality

    Expected: 8
    Received: 7

      610 |       verify(result, r => {
    > 611 |         expect(GitProcess.parseError(r.stderr)).toBe(GitError.MergeConflicts)
          |                                                 ^
      612 |       })
      613 |     })
      614 |   })
```

Now:

```
    expect(result).toHaveGitError(gitError)

    Expected
      "MergeConflicts"
    Received:
      "RebaseConflicts"

      607 |       const result = await GitProcess.exec(['rebase', 'my-branch'], repoPath)
      608 |
    > 609 |       expect(result).toHaveGitError(GitError.MergeConflicts)
          |                      ^
      610 |     })
      611 |   })
      612 | })
```

Follow-up notes: Maybe we could make the `parseError()` method accept a `result` object, so the logic that decides whether to use `stderr` or `stdout` remains in this package instead of Desktop (also, we need to fix [that logic in Desktop](https://github.com/desktop/desktop/blob/development/app/src/lib/git/core.ts#L156-L159), since it's using a non-strict comparison which will cause the first defined error (`SSHKeyAuditUnverified`, which has value `0`) to never match if it's returned in `stderr`).

