### PR TITLE
Detect correctly rebase errors on Git v2.26.x

### DIFF
--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -69,7 +69,7 @@ export const GitErrorRegexes: { [regexp: string]: GitError } = {
   "fatal: unable to access '(.+)': Failed to connect to (.+): Host is down": GitError.HostDown,
   "Cloning into '(.+)'...\nfatal: unable to access '(.+)': Could not resolve host: (.+)":
     GitError.HostDown,
-  'Failed to merge in the changes.': GitError.RebaseConflicts,
+  'Resolve all conflicts manually, mark them as resolved with': GitError.RebaseConflicts,
   '(Merge conflict|Automatic merge failed; fix conflicts and then commit the result)':
     GitError.MergeConflicts,
   "fatal: repository '(.+)' not found": GitError.HTTPSRepositoryNotFound,

--- a/test/fast/git-process-test.ts
+++ b/test/fast/git-process-test.ts
@@ -550,5 +550,59 @@ mark them as resolved using git add`
 
       expect(result).toHaveGitError(GitError.RebaseWithLocalChanges)
     })
+
+    it('can parse an error when there is a conflict while merging', async () => {
+      const repoPath = await initialize('desktop-pullrebase-with-local-changes')
+      const readmePath = path.join(repoPath, 'Readme.md')
+
+      // Create a commit on the default branch.
+      fs.writeFileSync(readmePath, '# README', { encoding: 'utf8' })
+      await GitProcess.exec(['add', '.'], repoPath)
+      await GitProcess.exec(['commit', '-m', '"initial commit"'], repoPath)
+
+      // Create a branch and add another commit.
+      await GitProcess.exec(['checkout', '-b', 'my-branch'], repoPath)
+      fs.writeFileSync(readmePath, '# README from my-branch', { encoding: 'utf8' })
+      await GitProcess.exec(['add', '.'], repoPath)
+      await GitProcess.exec(['commit', '-m', '"modify README in my-branch"'], repoPath)
+
+      // Go back to the default branch and add a commit that conflicts.
+      await GitProcess.exec(['checkout', '-'], repoPath)
+      fs.writeFileSync(readmePath, '# README from default', { encoding: 'utf8' })
+      await GitProcess.exec(['add', '.'], repoPath)
+      await GitProcess.exec(['commit', '-m', '"modifiy README in default branch"'], repoPath)
+
+      // Try to merge the branch.
+      const result = await GitProcess.exec(['merge', 'my-branch'], repoPath)
+
+      expect(result).toHaveGitError(GitError.MergeConflicts)
+    })
+
+    it('can parse an error when there is a conflict while rebasing', async () => {
+      const repoPath = await initialize('desktop-pullrebase-with-local-changes')
+      const readmePath = path.join(repoPath, 'Readme.md')
+
+      // Create a commit on the default branch.
+      fs.writeFileSync(readmePath, '# README', { encoding: 'utf8' })
+      await GitProcess.exec(['add', '.'], repoPath)
+      await GitProcess.exec(['commit', '-m', '"initial commit"'], repoPath)
+
+      // Create a branch and add another commit.
+      await GitProcess.exec(['checkout', '-b', 'my-branch'], repoPath)
+      fs.writeFileSync(readmePath, '# README from my-branch', { encoding: 'utf8' })
+      await GitProcess.exec(['add', '.'], repoPath)
+      await GitProcess.exec(['commit', '-m', '"modify README in my-branch"'], repoPath)
+
+      // Go back to the default branch and add a commit that conflicts.
+      await GitProcess.exec(['checkout', '-'], repoPath)
+      fs.writeFileSync(readmePath, '# README from default', { encoding: 'utf8' })
+      await GitProcess.exec(['add', '.'], repoPath)
+      await GitProcess.exec(['commit', '-m', '"modifiy README in default branch"'], repoPath)
+
+      // Try to merge the branch.
+      const result = await GitProcess.exec(['rebase', 'my-branch'], repoPath)
+
+      expect(result).toHaveGitError(GitError.RebaseConflicts)
+    })
   })
 })


### PR DESCRIPTION
*This PR is based on https://github.com/desktop/dugite/pull/406 to be able to use the custom matcher*

---

After upgrading to Git v2.26.x, the rebase errors have not been correctly parsed. This is caused by the change of the default rebase backend in git v2.26 ([more info](https://github.com/desktop/desktop/pull/10077#issuecomment-648951880)), which has change the errors displayed when there's a conflict while rebasing.

As part of this PR I've added better tests for these specific errors so we can catch them earlier next time their output changes.