### PR TITLE
Stop testing on node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ branches:
 
 language: node_js
 node_js:
-  - '8'
   - '10'
   - '12'
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,6 @@ platform:
 environment:
   DUGITE_CACHE_DIR: '%USERPROFILE%\.dugite\'
   matrix:
-    - nodejs_version: '8'
     - nodejs_version: '10'
     - nodejs_version: '12'
 


### PR DESCRIPTION
We're spending a lot of time queued waiting for available runners on AppVeyor

![image](https://user-images.githubusercontent.com/634063/86348803-7855e980-bc60-11ea-87cc-bfdf01a0b577.png)

Let's save a little time by not caring about node 8 any more.