### PR TITLE
Download x64 Git on Apple Silicon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,18 @@ jobs:
         include:
           - os: macos-10.15
             friendlyName: macOS
+            arch: x64
+          - os: macos-10.15
+            friendlyName: macOS
+            arch: arm64
           - os: windows-2019
             friendlyName: Windows
           - os: windows-2019
             friendlyName: Windows
             arch: x86
+          - os: windows-2019
+            friendlyName: Windows
+            arch: arm64
           - os: ubuntu-18.04
             friendlyName: Linux
     timeout-minutes: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,18 +18,11 @@ jobs:
         include:
           - os: macos-10.15
             friendlyName: macOS
-            arch: x64
-          - os: macos-10.15
-            friendlyName: macOS
-            arch: arm64
           - os: windows-2019
             friendlyName: Windows
           - os: windows-2019
             friendlyName: Windows
             arch: x86
-          - os: windows-2019
-            friendlyName: Windows
-            arch: arm64
           - os: ubuntu-18.04
             friendlyName: Linux
     timeout-minutes: 10

--- a/script/config.js
+++ b/script/config.js
@@ -28,6 +28,12 @@ function getConfig() {
     arch = 'ia32';
   }
 
+  if (process.platform === 'darwin' && arch === 'arm64') {
+    // Use the Dugite Native x64 package for MacOS arm64 (arm64 can run x64 code through emulation with Rosetta)
+    console.log('Downloading x64 Dugite Native for Apple Silicon (arm64)');
+    arch = 'x64';
+  }
+
   // Os.arch() calls it x32, we use x86 in actions, dugite-native calls it x86 and our embedded-git.json calls it ia32
   if (arch === 'x32' || arch === 'x86') {
     arch = 'ia32'


### PR DESCRIPTION
Similar to https://github.com/desktop/dugite/pull/392, this PR downloads x64 Git on Apple Silicon (since `dugite-native` doesn't have a native package for Apple Silicon yet). It's a quick fix to get us further with https://github.com/desktop/desktop/pull/11021; at a later stage a native Git package for Apple Silicon can be created for better performance on Apple Silicon.