### PR TITLE
Fix CI failure due to use of deprecated commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           submodules: recursive
       - name: Install Node.js ${{ matrix.arch }}
-        uses: aminya/setup-node@9acb334
+        uses: aminya/setup-node@0cf46aa
         with:
           node-version: 12
           node-arch: ${{ matrix.arch }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           submodules: recursive
       - name: Install Node.js ${{ matrix.arch }}
-        uses: aminya/setup-node@0cf46aa
+        uses: niik/setup-node@f9547c9
         with:
           node-version: 12
           node-arch: ${{ matrix.arch }}


### PR DESCRIPTION
We're using a third-party version of setup-node until https://github.com/actions/setup-node/issues/190 is resolved. Unfortunately that third-party fork does not include the fix for https://github.com/actions/setup-node/issues/212 so I've had to create yet another fork of the fork to get both the add-path fix and the configurable architecture.