### PR TITLE
Release 1.94.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dugite",
-  "version": "1.93.0",
+  "version": "1.94.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dugite",
-  "version": "1.93.0",
+  "version": "1.94.0",
   "description": "Elegant bindings for Git",
   "main": "./build/lib/index.js",
   "typings": "./build/lib/index.d.ts",

--- a/script/embedded-git.json
+++ b/script/embedded-git.json
@@ -1,22 +1,22 @@
 {
   "win32-x64": {
-    "name": "dugite-native-v2.26.2-3aca821-windows-x64.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.26.2-2/dugite-native-v2.26.2-3aca821-windows-x64.tar.gz",
-    "checksum": "51b776ac5b367a9018ae71b063ef2ef70bebeaac41b41a6c6aab6e9d9135d7b6"
+    "name": "dugite-native-v2.26.2-8da9a6e-windows-x64.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.26.2-3/dugite-native-v2.26.2-8da9a6e-windows-x64.tar.gz",
+    "checksum": "dd1da811e4e1e7bc2308fe389ff22f6498d477e30fc4fb2e476cd42fac094615"
   },
   "win32-ia32": {
-    "name": "dugite-native-v2.26.2-3aca821-windows-x86.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.26.2-2/dugite-native-v2.26.2-3aca821-windows-x86.tar.gz",
-    "checksum": "2c4fe99c643687b1a1f4a206ebab3be6a924a40567d467acbb4a7aa8bd8d7c87"
+    "name": "dugite-native-v2.26.2-8da9a6e-windows-x86.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.26.2-3/dugite-native-v2.26.2-8da9a6e-windows-x86.tar.gz",
+    "checksum": "e6a9a2c9d8a0a73ed59cc6e4a212f7baada9d6e5f3366274d1cb5055cc848354"
   },
   "darwin-x64": {
-    "name": "dugite-native-v2.26.2-3aca821-macOS.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.26.2-2/dugite-native-v2.26.2-3aca821-macOS.tar.gz",
-    "checksum": "17f0e43d49b988a766018a9b7067ac19e012f00a56bc8ee1e6b053678c4da275"
+    "name": "dugite-native-v2.26.2-8da9a6e-macOS.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.26.2-3/dugite-native-v2.26.2-8da9a6e-macOS.tar.gz",
+    "checksum": "7bfce55a983c334e4e5ce2d13d6d8baf07f03689ecdd8fb1e4a46387987920d8"
   },
   "linux-x64": {
-    "name": "dugite-native-v2.26.2-3aca821-ubuntu.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.26.2-2/dugite-native-v2.26.2-3aca821-ubuntu.tar.gz",
-    "checksum": "cded61f99f4876f7e14268505387429003d4371c424d15c33dff9aeadcde2052"
+    "name": "dugite-native-v2.26.2-8da9a6e-ubuntu.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.26.2-3/dugite-native-v2.26.2-8da9a6e-ubuntu.tar.gz",
+    "checksum": "79deff01dc14b97bd3be7f5758e0d4b3fe424f3a0fe972b38ab9926892c20662"
   }
 }

--- a/script/embedded-git.json
+++ b/script/embedded-git.json
@@ -1,22 +1,22 @@
 {
   "win32-x64": {
-    "name": "dugite-native-v2.26.2-0c90eda-windows-x64.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.26.2-1/dugite-native-v2.26.2-0c90eda-windows-x64.tar.gz",
-    "checksum": "4b729ed31c1972b4c0972f7ab8dbe64b867ce8c148b58fb103e0a3073695fdf0"
+    "name": "dugite-native-v2.26.2-3aca821-windows-x64.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.26.2-2/dugite-native-v2.26.2-3aca821-windows-x64.tar.gz",
+    "checksum": "51b776ac5b367a9018ae71b063ef2ef70bebeaac41b41a6c6aab6e9d9135d7b6"
   },
   "win32-ia32": {
-    "name": "dugite-native-v2.26.2-0c90eda-windows-x86.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.26.2-1/dugite-native-v2.26.2-0c90eda-windows-x86.tar.gz",
-    "checksum": "5306075f99e23f402f4af96071b0c8b7e66ff433d2115755e22fafd5d7e2fe92"
+    "name": "dugite-native-v2.26.2-3aca821-windows-x86.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.26.2-2/dugite-native-v2.26.2-3aca821-windows-x86.tar.gz",
+    "checksum": "2c4fe99c643687b1a1f4a206ebab3be6a924a40567d467acbb4a7aa8bd8d7c87"
   },
   "darwin-x64": {
-    "name": "dugite-native-v2.26.2-0c90eda-macOS.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.26.2-1/dugite-native-v2.26.2-0c90eda-macOS.tar.gz",
-    "checksum": "8613ce323c5b2ee36adb079137c3f2b907bffa194500d966ce663fe4e77e8bca"
+    "name": "dugite-native-v2.26.2-3aca821-macOS.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.26.2-2/dugite-native-v2.26.2-3aca821-macOS.tar.gz",
+    "checksum": "17f0e43d49b988a766018a9b7067ac19e012f00a56bc8ee1e6b053678c4da275"
   },
   "linux-x64": {
-    "name": "dugite-native-v2.26.2-0c90eda-ubuntu.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.26.2-1/dugite-native-v2.26.2-0c90eda-ubuntu.tar.gz",
-    "checksum": "0521c4e1786d59ad24f8c8fcd325ee7475496cdeac39bb87bb0d04f8f69cb0b9"
+    "name": "dugite-native-v2.26.2-3aca821-ubuntu.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.26.2-2/dugite-native-v2.26.2-3aca821-ubuntu.tar.gz",
+    "checksum": "cded61f99f4876f7e14268505387429003d4371c424d15c33dff9aeadcde2052"
   }
 }

--- a/test/fast/git-process-test.ts
+++ b/test/fast/git-process-test.ts
@@ -13,9 +13,9 @@ const temp = require('temp').track()
 describe('git-process', () => {
   it('can launch git', async () => {
     const result = await GitProcess.exec(['--version'], __dirname)
-    verify(result, r => {
-      expect(r.stdout).toContain(`git version ${gitVersion}`)
-    })
+    expect(result.stderr).toBe('')
+    expect(result.stdout).toContain(`git version ${gitVersion}`)
+    expect(result.exitCode).toBe(0)
   })
 
   describe('exitCode', () => {

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -2,7 +2,7 @@ import { GitProcess, IGitResult, GitError } from '../lib'
 
 // NOTE: bump these versions to the latest stable releases
 export const gitVersion = '2.26.'
-export const gitLfsVersion = '2.12.1'
+export const gitLfsVersion = '2.13.2'
 
 const temp = require('temp').track()
 


### PR DESCRIPTION
- Bumps dugite-native in order to get Git LFS 2.13.2 (CVE-2021-21237)