### PR TITLE
[WIP] Windows ARM64 POC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,13 @@ jobs:
           submodules: recursive
       - name: Install Node.js ${{ matrix.arch }}
         if: matrix.arch != 'arm64'
-        uses: niik/setup-node@f9547c9
+        uses: niik/setup-node@f9547c97f4c519f71dc42e652d6d2c53f9527c1d
         with:
           node-version: 12
           node-arch: ${{ matrix.arch }}
       - name: Install Node.js ${{ matrix.arch }}
         if: matrix.arch == 'arm64'
-        uses: niik/setup-node@f9547c9
+        uses: niik/setup-node@f9547c97f4c519f71dc42e652d6d2c53f9527c1d
         with:
           node-version: 12
           node-arch: x64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
           - os: windows-2019
             friendlyName: Windows
             arch: x86
+          - os: windows-2019
+            friendlyName: Windows
+            arch: arm64
           - os: ubuntu-18.04
             friendlyName: Linux
     timeout-minutes: 10
@@ -31,10 +34,17 @@ jobs:
         with:
           submodules: recursive
       - name: Install Node.js ${{ matrix.arch }}
+        if: matrix.arch != 'arm64'
         uses: niik/setup-node@f9547c9
         with:
           node-version: 12
           node-arch: ${{ matrix.arch }}
+      - name: Install Node.js ${{ matrix.arch }}
+        if: matrix.arch == 'arm64'
+        uses: niik/setup-node@f9547c9
+        with:
+          node-version: 12
+          node-arch: x64
       - name: Install and build dependencies
         run: npm ci
         env:
@@ -44,6 +54,7 @@ jobs:
       - name: Lint
         run: npm run is-it-pretty
       - name: Test
+        if: matrix.arch != 'arm64'
         run: npm run test
         env:
           TEST: 1

--- a/lib/git-environment.ts
+++ b/lib/git-environment.ts
@@ -55,6 +55,8 @@ function resolveGitExecPath(): string {
   if (process.platform === 'win32') {
     if (process.arch === 'x64') {
       return path.join(gitDir, 'mingw64', 'libexec', 'git-core')
+    } else if (process.arch === 'arm64') {
+      return path.join(gitDir, 'arm64', 'libexec', 'git-core')
     }
 
     return path.join(gitDir, 'mingw32', 'libexec', 'git-core')
@@ -82,6 +84,13 @@ export function setupEnvironment(
   if (process.platform === 'win32') {
     if (process.arch === 'x64') {
       envPath = `${gitDir}\\mingw64\\bin;${gitDir}\\mingw64\\usr\\bin;${envPath}`
+    } else if (process.arch === 'arm64') {
+      /**
+       * Git for Windows arm64 doesn't have all binaries available natively yet,
+       * but we can leverage 32-bit emulation on this platform. Therefore we fallback
+       * to mingw32 binaries in case native ones aren't available.
+       */
+      envPath = `${gitDir}\\arm64\\bin;${gitDir}\\arm64\\usr\\bin;${gitDir}\\mingw32\\bin;${gitDir}\\mingw32\\usr\\bin;${envPath}`
     } else {
       envPath = `${gitDir}\\mingw32\\bin;${gitDir}\\mingw32\\usr\\bin;${envPath}`
     }

--- a/script/config.js
+++ b/script/config.js
@@ -22,12 +22,6 @@ function getConfig() {
     arch = process.env.npm_config_arch;
   }
 
-  if (process.platform === 'win32' && arch === 'arm64') {
-    // Use the Dugite Native ia32 package for Windows arm64 (arm64 can run 32-bit code through emulation)
-    console.log('Downloading 32-bit Dugite Native for Windows arm64');
-    arch = 'ia32';
-  }
-
   if (process.platform === 'darwin' && arch === 'arm64') {
     // Use the Dugite Native x64 package for MacOS arm64 (arm64 can run x64 code through emulation with Rosetta)
     console.log('Downloading x64 Dugite Native for Apple Silicon (arm64)');

--- a/script/embedded-git.json
+++ b/script/embedded-git.json
@@ -9,6 +9,11 @@
     "url": "https://github.com/desktop/dugite-native/releases/download/v2.29.2-2/dugite-native-v2.29.2-f9ceb12-windows-x86.tar.gz",
     "checksum": "a983bd0e0fedc994906a3759a19325038a29ba8f172f93576d7b2ea0c5f72e44"
   },
+  "win32-arm64": {
+    "name": "dugite-native-v2.30.0-f58d9fd-windows-arm64.tar.gz",
+    "url": "https://github.com/dennisameling/dugite-native/releases/download/v2.30.0-beta/dugite-native-v2.30.0-f58d9fd-windows-arm64.tar.gz",
+    "checksum": "2d5cb56283a3522ed80a16634c3b84e61da3e090c80db66f182136a35bfb1c2e"
+  },
   "darwin-x64": {
     "name": "dugite-native-v2.29.2-f9ceb12-macOS.tar.gz",
     "url": "https://github.com/desktop/dugite-native/releases/download/v2.29.2-2/dugite-native-v2.29.2-f9ceb12-macOS.tar.gz",

--- a/script/embedded-git.json
+++ b/script/embedded-git.json
@@ -10,9 +10,9 @@
     "checksum": "a983bd0e0fedc994906a3759a19325038a29ba8f172f93576d7b2ea0c5f72e44"
   },
   "win32-arm64": {
-    "name": "dugite-native-v2.30.0-f58d9fd-windows-arm64.tar.gz",
-    "url": "https://github.com/dennisameling/dugite-native/releases/download/v2.30.0-beta/dugite-native-v2.30.0-f58d9fd-windows-arm64.tar.gz",
-    "checksum": "2d5cb56283a3522ed80a16634c3b84e61da3e090c80db66f182136a35bfb1c2e"
+    "name": "dugite-native-v2.29.2-5aad8ba-windows-arm64.tar.gz",
+    "url": "https://github.com/dennisameling/dugite-native/releases/download/v2.31.0-rc6/dugite-native-v2.29.2-5aad8ba-windows-arm64.tar.gz",
+    "checksum": "abd38f61068f7c67a8747517910f3762e12b2f873427e480a82985dff02e42a8"
   },
   "darwin-x64": {
     "name": "dugite-native-v2.29.2-f9ceb12-macOS.tar.gz",

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,7 +1,12 @@
 import { GitProcess, IGitResult, GitError } from '../lib'
 
 // NOTE: bump these versions to the latest stable releases
-export const gitVersion = '2.29.2'
+let gitV = '2.29.2'
+if (process.arch == 'arm64') {
+  gitV = '2.31.'
+}
+
+export const gitVersion = gitV
 export const gitLfsVersion = '2.13.2'
 
 const temp = require('temp').track()


### PR DESCRIPTION
Uses https://github.com/desktop/dugite-native/pull/347

We're [working on a native ARM64 version](https://github.com/git-for-windows/git/issues/2346#issuecomment-751687623) of Git for Windows 🚀 Since Dugite Native uses the MinGit packages provided by Git for Windows, this is a good opportunity for us to test if Dugite tests are passing.

This PR will likely remain WIP for a while until we're ready to publish the production builds of Git for Windows ARM64.

First test results - most are passing 🎉:

```
C:\repos\dugite>npm run test

> dugite@1.95.0 test C:\repos\dugite
> npm run test:fast && npm run test:slow && npm run test:external


> dugite@1.95.0 test:fast C:\repos\dugite
> cross-env LOCAL_GIT_DIRECTORY=./git/ jest --runInBand --silent --config ./jest.fast.config.js

 FAIL  test/fast/git-process-test.ts (12.832s)
  ● git-process › errors › can parse an error when pulling with merge with local changes

    expect(result).toHaveGitError(gitError)

    Expected
      "MergeWithLocalChanges"
    Received:
      null

      512 |       const result = await GitProcess.exec(['pull', 'origin', 'HEAD'], forkRepoPath)
      513 | 
    > 514 |       expect(result).toHaveGitError(GitError.MergeWithLocalChanges)
          |                      ^
      515 |     })
      516 | 
      517 |     it('can parse an error when pulling with rebase with local changes', async () => {

      at Object.<anonymous> (test/fast/git-process-test.ts:514:22)
      at fulfilled (test/fast/git-process-test.ts:7:24)

  ● git-process › errors › can parse an error when pulling with rebase with local changes

    expect(result).toHaveGitError(gitError)

    Expected
      "RebaseWithLocalChanges"
    Received:
      null

      549 |       const result = await GitProcess.exec(['pull', 'origin', 'HEAD'], forkRepoPath)
      550 | 
    > 551 |       expect(result).toHaveGitError(GitError.RebaseWithLocalChanges)
          |                      ^
      552 |     })
      553 | 
      554 |     it('can parse an error when there is a conflict while merging', async () => {

      at Object.<anonymous> (test/fast/git-process-test.ts:551:22)
      at fulfilled (test/fast/git-process-test.ts:7:24)

 FAIL  test/fast/errors-test.ts
  ● detects errors › RemoteAlreadyExists

    expect(result).toHaveGitError(gitError)

    Expected
      "RemoteAlreadyExists"
    Received:
      null

      15 |     )
      16 | 
    > 17 |     expect(result).toHaveGitError(GitError.RemoteAlreadyExists)
         |                    ^
      18 |   })
      19 |   it('TagAlreadyExists', async () => {
      20 |     const repoPath = await initialize('tag-already-exists-test-repo')

      at Object.<anonymous> (test/fast/errors-test.ts:17:20)
      at fulfilled (test/fast/errors-test.ts:7:24)

 FAIL  test/fast/config-test.ts
  ● config › sets http.sslBackend on Windows

    expect(received).toBe(expected) // Object.is equality

    Expected: "schannel"
    Received: ""

       6 |     if (process.platform === 'win32') {
       7 |       const result = await GitProcess.exec(['config', '--system', 'http.sslBackend'], os.homedir())
    >  8 |       expect(result.stdout.trim()).toBe('schannel')
         |                                    ^
       9 |     }
      10 |   })
      11 | 

      at Object.<anonymous> (test/fast/config-test.ts:8:36)
      at fulfilled (test/fast/config-test.ts:7:24)

 PASS  test/fast/lfs-test.ts
 PASS  test/fast/commit-test.ts
 PASS  test/fast/stdin-test.ts
 PASS  test/fast/status-test.ts
 PASS  test/fast/environment-test.ts

Test Suites: 3 failed, 5 passed, 8 total
Tests:       4 failed, 56 passed, 60 total
Snapshots:   0 total
Time:        17.173s, estimated 19s
```

[GitHub Desktop](https://github.com/desktop/desktop) tests with this PR:

```
Test Suites: 13 failed, 88 passed, 101 total
Tests:       45 failed, 6 skipped, 842 passed, 893 total
Snapshots:   4 passed, 4 total
Time:        431.078s
```