### PR TITLE
execTask.cancel()

### DIFF
--- a/test/fast/git-process-test.ts
+++ b/test/fast/git-process-test.ts
@@ -2,7 +2,12 @@ import * as path from 'path'
 import * as fs from 'fs'
 import * as crypto from 'crypto'
 
-import { GitProcess, GitError, RepositoryDoesNotExistErrorCode, GitTaskCancelResult } from '../../lib'
+import {
+  GitProcess,
+  GitError,
+  RepositoryDoesNotExistErrorCode,
+  GitTaskCancelResult
+} from '../../lib'
 import { GitErrorRegexes } from '../../lib/errors'
 import { initialize, verify, initializeWithRemote, gitForWindowsVersion } from '../helpers'
 
@@ -13,7 +18,7 @@ const temp = require('temp').track()
 
 describe('git-process', () => {
   it('clone-and-cancel', async () => {
-    fs.mkdtemp('desktop-git-clone-and-cancel',async (err,folder)=>{
+    fs.mkdtemp('desktop-git-clone-and-cancel', async (err, folder) => {
       const options = {
         env: setupNoAuth()
       }

--- a/test/fast/git-process-test.ts
+++ b/test/fast/git-process-test.ts
@@ -2,15 +2,29 @@ import * as path from 'path'
 import * as fs from 'fs'
 import * as crypto from 'crypto'
 
-import { GitProcess, GitError, RepositoryDoesNotExistErrorCode } from '../../lib'
+import { GitProcess, GitError, RepositoryDoesNotExistErrorCode, GitTaskCancelResult } from '../../lib'
 import { GitErrorRegexes } from '../../lib/errors'
 import { initialize, verify, initializeWithRemote, gitForWindowsVersion } from '../helpers'
 
 import { gitVersion } from '../helpers'
+import { setupNoAuth } from '../slow/auth'
 
 const temp = require('temp').track()
 
 describe('git-process', () => {
+  it('clone-and-cancel', async () => {
+    const testCancelRepoPath = temp.mkdirSync('desktop-git-clone-and-cancel')
+    const options = {
+      env: setupNoAuth()
+    }
+    const result = GitProcess.execTask(
+      ['clone', '--', 'https://github.com/maifeeulasad/maifeeulasad.github.io', '.'],
+      testCancelRepoPath,
+      options
+    )
+    expect(await result.cancel()).toBe(GitTaskCancelResult.successfulCancel)
+  })
+
   it('can launch git', async () => {
     const result = await GitProcess.exec(['--version'], __dirname)
     expect(result.stderr).toBe('')

--- a/test/fast/git-process-test.ts
+++ b/test/fast/git-process-test.ts
@@ -1,6 +1,7 @@
 import * as path from 'path'
 import * as fs from 'fs'
 import * as crypto from 'crypto'
+import * as os from 'os'
 
 import {
   GitProcess,
@@ -18,17 +19,20 @@ const temp = require('temp').track()
 
 describe('git-process', () => {
   it('clone-and-cancel', async () => {
-    fs.mkdtemp('desktop-git-clone-and-cancel', async (err, folder) => {
-      const options = {
-        env: setupNoAuth()
-      }
-      const result = GitProcess.execTask(
-        ['clone', 'https://github.com/maifeeulasad/maifeeulasad.github.io', folder],
-        folder,
-        options
-      )
-      expect(await result.cancel()).toBe(GitTaskCancelResult.successfulCancel)
-    })
+    const tempDir = path.join(os.tmpdir(), 'desktop-git-clone-and-cancel-')
+
+    const folder = fs.mkdtempSync(tempDir)
+    const options = {
+      env: setupNoAuth()
+    }
+    const task = GitProcess.execTask(
+      ['clone', '--', 'https://github.com/maifeeulasad/maifeeulasad.github.io', folder],
+      folder,
+      options
+    )
+    const cancelResult = await task.cancel()
+    await task.result
+    expect(cancelResult).toBe(GitTaskCancelResult.successfulCancel)
   })
 
   it('can launch git', async () => {

--- a/test/fast/git-process-test.ts
+++ b/test/fast/git-process-test.ts
@@ -23,7 +23,7 @@ describe('git-process', () => {
         env: setupNoAuth()
       }
       const result = GitProcess.execTask(
-        ['clone', '--', 'https://github.com/maifeeulasad/maifeeulasad.github.io', '.'],
+        ['clone', 'https://github.com/maifeeulasad/maifeeulasad.github.io', folder],
         folder,
         options
       )

--- a/test/fast/git-process-test.ts
+++ b/test/fast/git-process-test.ts
@@ -13,16 +13,17 @@ const temp = require('temp').track()
 
 describe('git-process', () => {
   it('clone-and-cancel', async () => {
-    const testCancelRepoPath = temp.mkdirSync('desktop-git-clone-and-cancel')
-    const options = {
-      env: setupNoAuth()
-    }
-    const result = GitProcess.execTask(
-      ['clone', '--', 'https://github.com/maifeeulasad/maifeeulasad.github.io', '.'],
-      testCancelRepoPath,
-      options
-    )
-    expect(await result.cancel()).toBe(GitTaskCancelResult.successfulCancel)
+    fs.mkdtemp('desktop-git-clone-and-cancel',async (err,folder)=>{
+      const options = {
+        env: setupNoAuth()
+      }
+      const result = GitProcess.execTask(
+        ['clone', '--', 'https://github.com/maifeeulasad/maifeeulasad.github.io', '.'],
+        folder,
+        options
+      )
+      expect(await result.cancel()).toBe(GitTaskCancelResult.successfulCancel)
+    })
   })
 
   it('can launch git', async () => {


### PR DESCRIPTION
First I tried this, something like this:
```
temp.mkdirSync('desktop-git-clone-and-cancel')
...
const result = GitProcess.execTask(
      ['clone', '--', 'https://github.com/maifeeulasad/maifeeulasad.github.io', '.'],
      testCancelRepoPath,
      options
    )
expect(await result.cancel()).toBe(GitTaskCancelResult.successfulCancel)
```
But it gave me: **exitCode › returns exit code when folder is empty**

So I tried `fs.mkdtemp(_,folder)`

But now I get: **exitCode › handles stdin closed errors**