### PR TITLE
Release 1.103.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dugite",
-  "version": "1.102.0",
+  "version": "1.103.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dugite",
-  "version": "1.102.0",
+  "version": "1.103.0",
   "description": "Elegant bindings for Git",
   "main": "./build/lib/index.js",
   "typings": "./build/lib/index.d.ts",


### PR DESCRIPTION
- Bump dugite-native to v2.29.3 in order to get arm64 builds of git and git-lfs for macOS - #439
