### PR TITLE
Add parse test for unsafe directory error

### DIFF
--- a/test/fast/errors-test.ts
+++ b/test/fast/errors-test.ts
@@ -1,8 +1,11 @@
 import { GitProcess, GitError } from '../../lib'
 import { initialize } from '../helpers'
-import { writeFileSync } from 'fs'
+import { realpath, writeFileSync } from 'fs'
 import { join } from 'path'
 import { GitErrorRegexes } from '../../lib/errors'
+import { promisify } from 'util'
+
+const pRealPath = promisify(realpath)
 
 describe('detects errors', () => {
   it('RemoteAlreadyExists', async () => {
@@ -58,7 +61,8 @@ describe('detects errors', () => {
     expect(errorEntry).not.toBe(null)
 
     const m = result.stderr.match(errorEntry![0])
-    const comparePath = process.platform === 'win32' ? path.replace(/\\/g, '/') : path
+    const comparePath =
+      process.platform === 'win32' ? (await pRealPath(path)).replace(/\\/g, '/') : path
 
     // toContain because of realpath and we don't care about /private/ on macOS
     expect(m![1]).toContain(comparePath)

--- a/test/fast/errors-test.ts
+++ b/test/fast/errors-test.ts
@@ -1,11 +1,8 @@
 import { GitProcess, GitError } from '../../lib'
 import { initialize } from '../helpers'
-import { realpath, writeFileSync } from 'fs'
+import { realpathSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { GitErrorRegexes } from '../../lib/errors'
-import { promisify } from 'util'
-
-const pRealPath = promisify(realpath)
 
 describe('detects errors', () => {
   it('RemoteAlreadyExists', async () => {
@@ -62,9 +59,9 @@ describe('detects errors', () => {
 
     const m = result.stderr.match(errorEntry![0])
     const comparePath =
-      process.platform === 'win32' ? (await pRealPath(path)).replace(/\\/g, '/') : path
+      process.platform === 'win32' ? realpathSync(path).replace(/\\/g, '/') : realpathSync(path)
 
     // toContain because of realpath and we don't care about /private/ on macOS
-    expect(m![1]).toContain(comparePath)
+    expect(m![1]).toBe(comparePath)
   })
 })

--- a/test/fast/errors-test.ts
+++ b/test/fast/errors-test.ts
@@ -1,6 +1,6 @@
 import { GitProcess, GitError } from '../../lib'
 import { initialize } from '../helpers'
-import { realpathSync, writeFileSync } from 'fs'
+import { writeFileSync } from 'fs'
 import { join } from 'path'
 import { GitErrorRegexes } from '../../lib/errors'
 
@@ -41,7 +41,8 @@ describe('detects errors', () => {
     expect(result).toHaveGitError(GitError.BranchAlreadyExists)
   })
   it('UnsafeDirectory', async () => {
-    const path = await initialize('branch-already-exists')
+    const repoName = 'branch-already-exists'
+    const path = await initialize(repoName)
 
     const result = await GitProcess.exec(['status'], path, {
       env: {
@@ -56,12 +57,9 @@ describe('detects errors', () => {
     )
 
     expect(errorEntry).not.toBe(null)
-
     const m = result.stderr.match(errorEntry![0])
-    const comparePath =
-      process.platform === 'win32' ? realpathSync(path).replace(/\\/g, '/') : realpathSync(path)
 
     // toContain because of realpath and we don't care about /private/ on macOS
-    expect(m![1]).toBe(comparePath)
+    expect(m![1]).toContain(repoName)
   })
 })


### PR DESCRIPTION
Follow-up to #469, adds a test to verify that the Git error message for unsafe directories doesn't change from underneath us.