### PR TITLE
Unset git config safe.directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,11 @@ jobs:
         run: npm run build
       - name: Lint
         run: npm run is-it-pretty
-      - name: Unset git config safe.directory
-        run: git config --global --unset-all safe.directory
+      - name: Unset git config safe.directory globally
+        run: git config --global --unset-all safe.directory || true
+      - name: Unset git config safe.directory for linux
+        if: runner.os == 'Linux'
+        run: sudo git config --system --unset-all safe.directory || true
       - name: Test
         run: npm run test
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,8 @@ jobs:
         run: npm run build
       - name: Lint
         run: npm run is-it-pretty
+      - name: Unset git config safe.directory
+        run: git config --global --unset-all safe.directory
       - name: Test
         run: npm run test
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,11 +43,9 @@ jobs:
         run: npm run build
       - name: Lint
         run: npm run is-it-pretty
-      - name: Unset git config safe.directory globally
-        run: git config --global --unset-all safe.directory || true
-      - name: Unset git config safe.directory for linux
-        if: runner.os == 'Linux'
-        run: sudo git config --system --unset-all safe.directory || true
+      - name: Reset safe.directory
+        run: git config --global --add safe.directory ""
+        shell: bash
       - name: Test
         run: npm run test
         env:


### PR DESCRIPTION
Turns out the the actions runner was updated to set the the safe.directory=* which makes our tests of the unsafe directory check fail. This PR adds a job step to unset this (like it was before that change) so that our test can properly run tests again that setting. 