### PR TITLE
Require Node 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        nodeVersion: [12, 14, 16, 18]
+        nodeVersion: [14, 16, 18]
         arch: [x64]
         os: [macos-11, windows-2019, ubuntu-22.04]
         include:

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "update-embedded-git": "node ./script/update-embedded-git.js"
   },
   "engines": {
-    "node": ">= 12"
+    "node": ">= 14"
   },
   "repository": {
     "type": "git",

--- a/script/download-git.js
+++ b/script/download-git.js
@@ -4,7 +4,7 @@ const ProgressBar = require('progress')
 const tar = require('tar')
 const https = require('https')
 const { createHash } = require('crypto')
-const { rm, rmdir, mkdir, createReadStream, createWriteStream, existsSync } = require('fs')
+const { rm, mkdir, createReadStream, createWriteStream, existsSync } = require('fs')
 
 const config = require('./config')()
 
@@ -101,8 +101,7 @@ if (config.source === '') {
   process.exit(0)
 }
 
-// Node 12 didn't have rm, only rmdir
-;(rm || rmdir)(config.outputPath, { recursive: true, force: true }, error => {
+rm(config.outputPath, { recursive: true, force: true }, error => {
   if (error) {
     console.log(`Unable to clean directory at ${config.outputPath}`, error)
     process.exit(1)


### PR DESCRIPTION
Node 12 [isn't supported](https://nodejs.org/en/about/releases/) any more and we're planning on making the next dugite release a major version bump due to the breaking change of engine compatibility so let's ditch 12 as well.