### PR TITLE
simplify and correct arch detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
             friendlyName: Windows
             nodeVersion: 16
             arch: x86
+            npm_config_arch: ia32
           - os: ubuntu-22.04
             friendlyName: Linux
     timeout-minutes: 10
@@ -44,7 +45,7 @@ jobs:
       - name: Install and build dependencies
         run: yarn
         env:
-          npm_config_arch: ${{ matrix.arch }}
+          npm_config_arch: ${{ matrix.npm_config_arch }}
       - name: Build
         run: yarn build
       - name: Lint

--- a/script/config.js
+++ b/script/config.js
@@ -14,6 +14,7 @@ function getConfig() {
     tempFile: ''
   }
 
+  // Possible values are ‘x64’, ‘arm’, ‘arm64’, ‘s390’, ‘s390x’, ‘mipsel’, ‘ia32’, ‘mips’, ‘ppc’ and ‘ppc64’
   let arch = os.arch();
 
   if (process.env.npm_config_arch) {
@@ -26,11 +27,6 @@ function getConfig() {
     // Use the Dugite Native ia32 package for Windows arm64 (arm64 can run 32-bit code through emulation)
     console.log('Downloading 32-bit Dugite Native for Windows arm64');
     arch = 'ia32';
-  }
-
-  // Os.arch() calls it x32, we use x86 in actions, dugite-native calls it x86 and our embedded-git.json calls it ia32
-  if (arch === 'x32' || arch === 'x86') {
-    arch = 'ia32'
   }
 
   const key = `${process.platform}-${arch}`

--- a/script/update-embedded-git.js
+++ b/script/update-embedded-git.js
@@ -14,7 +14,7 @@ get(`https://api.github.com/repos/desktop/dugite-native/releases/latest`).then(
       'darwin-x64': await findMacOSx64BitRelease(assets),
       'darwin-arm64': await findMacOSARM64BitRelease(assets),
       'linux-x64': await findLinux64BitRelease(assets),
-      'linux-x86': await findLinux32BitRelease(assets),
+      'linux-ia32': await findLinux32BitRelease(assets),
       'linux-arm': await findLinuxARM32BitRelease(assets),
       'linux-arm64': await findLinuxARM64BitRelease(assets)
     }


### PR DESCRIPTION
'x32' is not a valid architecture in all released versions of node.js anymore. v8 dropped support for it in 2018