### PR TITLE
fix: missing require to `fs.rmSync`.

### DIFF
--- a/script/download-git.js
+++ b/script/download-git.js
@@ -4,7 +4,7 @@ const ProgressBar = require('progress')
 const tar = require('tar')
 const https = require('https')
 const { createHash } = require('crypto')
-const { rm, mkdir, createReadStream, createWriteStream, existsSync } = require('fs')
+const { rm, rmSync, mkdir, createReadStream, createWriteStream, existsSync } = require('fs')
 
 const config = require('./config')()
 


### PR DESCRIPTION
Hello, this PR aims to solve this issue:

https://github.com/desktop/dugite/issues/523

I was actually surprised by this issue. It is a very obvious and easily fixable error. Why didn't any official member handle it before? Was it simply because the path that used rmSync was hardly triggered? But due to [another issue with https_proxy](https://github.com/desktop/dugite/issues/148), this path can be easily triggered on Windows.