### PR TITLE
Releases v2.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dugite",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Elegant bindings for Git",
   "main": "./build/lib/index.js",
   "typings": "./build/lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dugite",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Elegant bindings for Git",
   "main": "./build/lib/index.js",
   "typings": "./build/lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dugite",
-  "version": "2.5.0",
+  "version": "2.4.0",
   "description": "Elegant bindings for Git",
   "main": "./build/lib/index.js",
   "typings": "./build/lib/index.d.ts",

--- a/script/embedded-git.json
+++ b/script/embedded-git.json
@@ -1,27 +1,27 @@
 {
   "win32-x64": {
-    "name": "dugite-native-v2.39.3-887e871-windows-x64.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.39.3/dugite-native-v2.39.3-887e871-windows-x64.tar.gz",
-    "checksum": "04fccfb4ed18e72b82bf7a4d5489b97a61d07b027e44ac20a4c00ac8e5c0fac3"
+    "name": "dugite-native-v2.39.2-ddb2ace-windows-x64.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.39.2/dugite-native-v2.39.2-ddb2ace-windows-x64.tar.gz",
+    "checksum": "7d5a68de79c7ec981366c9543fc2f2c8e5160f8b41b3039767a046fc59e91367"
   },
   "win32-ia32": {
-    "name": "dugite-native-v2.39.3-887e871-windows-x86.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.39.3/dugite-native-v2.39.3-887e871-windows-x86.tar.gz",
-    "checksum": "850df5220f87f97653b2fb8efc4318b7c6eb9f4a2b46b6927eb13486838066a5"
+    "name": "dugite-native-v2.39.2-ddb2ace-windows-x86.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.39.2/dugite-native-v2.39.2-ddb2ace-windows-x86.tar.gz",
+    "checksum": "d9b75e5d2cbfc604e96a1b3822ac8b989898af39c9c9ed4bf05355d02f7cc778"
   },
   "darwin-x64": {
-    "name": "dugite-native-v2.39.3-887e871-macOS-x64.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.39.3/dugite-native-v2.39.3-887e871-macOS-x64.tar.gz",
-    "checksum": "7074046490e0788eafd647d79ea1118fd14632ef6008bbbb1183ec6952e18198"
+    "name": "dugite-native-v2.39.2-ddb2ace-macOS-x64.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.39.2/dugite-native-v2.39.2-ddb2ace-macOS-x64.tar.gz",
+    "checksum": "63861250a026e1b0d7d126375139237c8342b3963b5d73df89912db4cb921d24"
   },
   "darwin-arm64": {
-    "name": "dugite-native-v2.39.3-887e871-macOS-arm64.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.39.3/dugite-native-v2.39.3-887e871-macOS-arm64.tar.gz",
-    "checksum": "9c043ae08a739b195a517952dfd53be6fa56c7db26dcb6cab0931f0a7c905b9b"
+    "name": "dugite-native-v2.39.2-ddb2ace-macOS-arm64.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.39.2/dugite-native-v2.39.2-ddb2ace-macOS-arm64.tar.gz",
+    "checksum": "09b58004239dad007f7ac53839d8f2ce53b966992fd49244fb163fb98c22c989"
   },
   "linux-x64": {
-    "name": "dugite-native-v2.39.3-887e871-ubuntu.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.39.3/dugite-native-v2.39.3-887e871-ubuntu.tar.gz",
-    "checksum": "7a6c87e0010896c6580a09a973a3ba895ebbac4f980fbf57502615954e3cd24f"
+    "name": "dugite-native-v2.39.2-ddb2ace-ubuntu.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.39.2/dugite-native-v2.39.2-ddb2ace-ubuntu.tar.gz",
+    "checksum": "b08c173de92eecf653427810cbc9193efb3b39751690ec21196c79805038e738"
   }
 }

--- a/script/embedded-git.json
+++ b/script/embedded-git.json
@@ -1,27 +1,42 @@
 {
   "win32-x64": {
-    "name": "dugite-native-v2.39.2-ddb2ace-windows-x64.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.39.2/dugite-native-v2.39.2-ddb2ace-windows-x64.tar.gz",
-    "checksum": "7d5a68de79c7ec981366c9543fc2f2c8e5160f8b41b3039767a046fc59e91367"
+    "name": "dugite-native-v2.39.3-91ebaa8-windows-x64.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.39.3-1/dugite-native-v2.39.3-91ebaa8-windows-x64.tar.gz",
+    "checksum": "d52c40ac51637970ff8460308fe313daf27290e56a9cf92efbf2308551771660"
   },
   "win32-ia32": {
-    "name": "dugite-native-v2.39.2-ddb2ace-windows-x86.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.39.2/dugite-native-v2.39.2-ddb2ace-windows-x86.tar.gz",
-    "checksum": "d9b75e5d2cbfc604e96a1b3822ac8b989898af39c9c9ed4bf05355d02f7cc778"
+    "name": "dugite-native-v2.39.3-91ebaa8-windows-x86.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.39.3-1/dugite-native-v2.39.3-91ebaa8-windows-x86.tar.gz",
+    "checksum": "ec9d8c575e1c178c89093c391325b3b291f743f7530ffb9f023c3dd4dcc2d155"
   },
   "darwin-x64": {
-    "name": "dugite-native-v2.39.2-ddb2ace-macOS-x64.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.39.2/dugite-native-v2.39.2-ddb2ace-macOS-x64.tar.gz",
-    "checksum": "63861250a026e1b0d7d126375139237c8342b3963b5d73df89912db4cb921d24"
+    "name": "dugite-native-v2.39.3-91ebaa8-macOS-x64.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.39.3-1/dugite-native-v2.39.3-91ebaa8-macOS-x64.tar.gz",
+    "checksum": "84bcd256345a24ca087632aeb9a14989858f211883646bbd637dde56913a5017"
   },
   "darwin-arm64": {
-    "name": "dugite-native-v2.39.2-ddb2ace-macOS-arm64.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.39.2/dugite-native-v2.39.2-ddb2ace-macOS-arm64.tar.gz",
-    "checksum": "09b58004239dad007f7ac53839d8f2ce53b966992fd49244fb163fb98c22c989"
+    "name": "dugite-native-v2.39.3-91ebaa8-macOS-arm64.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.39.3-1/dugite-native-v2.39.3-91ebaa8-macOS-arm64.tar.gz",
+    "checksum": "37467de076043b59d9af274fdef9c2a4e00f0c9112ba9e2b839eae90ea8a9628"
   },
   "linux-x64": {
-    "name": "dugite-native-v2.39.2-ddb2ace-ubuntu.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.39.2/dugite-native-v2.39.2-ddb2ace-ubuntu.tar.gz",
-    "checksum": "b08c173de92eecf653427810cbc9193efb3b39751690ec21196c79805038e738"
+    "name": "dugite-native-v2.39.3-91ebaa8-ubuntu-x64.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.39.3-1/dugite-native-v2.39.3-91ebaa8-ubuntu-x64.tar.gz",
+    "checksum": "78375b97c802caa33c4ab585e3cf113001f0f53d0ab623ef0086e7c5b819189d"
+  },
+  "linux-x86": {
+    "name": "dugite-native-v2.39.3-91ebaa8-ubuntu-x86.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.39.3-1/dugite-native-v2.39.3-91ebaa8-ubuntu-x86.tar.gz",
+    "checksum": "1cd3511fc8a51556bdc88393cd344e0c084e7063c281137644765929ee092e8d"
+  },
+  "linux-arm": {
+    "name": "dugite-native-v2.39.3-91ebaa8-ubuntu-arm.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.39.3-1/dugite-native-v2.39.3-91ebaa8-ubuntu-arm.tar.gz",
+    "checksum": "331727414dc0d559758982f62adc9823c01e51ff302b5e5fe9e0cd783e5e1ea5"
+  },
+  "linux-arm64": {
+    "name": "dugite-native-v2.39.3-91ebaa8-ubuntu-arm64.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.39.3-1/dugite-native-v2.39.3-91ebaa8-ubuntu-arm64.tar.gz",
+    "checksum": "8af507edf110a285b72e7bc884aa2a3cc2ca09b687f0ea1366d7806c488b7bb6"
   }
 }

--- a/script/update-embedded-git.js
+++ b/script/update-embedded-git.js
@@ -13,7 +13,10 @@ get(`https://api.github.com/repos/desktop/dugite-native/releases/latest`).then(
       'win32-ia32': await findWindows32BitRelease(assets),
       'darwin-x64': await findMacOSx64BitRelease(assets),
       'darwin-arm64': await findMacOSARM64BitRelease(assets),
-      'linux-x64': await findLinux64BitRelease(assets)
+      'linux-x64': await findLinux64BitRelease(assets),
+      'linux-x86': await findLinux32BitRelease(assets),
+      'linux-arm': await findLinuxARM32BitRelease(assets),
+      'linux-arm64': await findLinuxARM64BitRelease(assets)
     }
 
     const fileContents = JSON.stringify(output, null, 2)
@@ -67,9 +70,33 @@ function findMacOSARM64BitRelease(assets) {
 }
 
 function findLinux64BitRelease(assets) {
-  const asset = assets.find(a => a.name.endsWith('-ubuntu.tar.gz'))
+  const asset = assets.find(a => a.name.endsWith('-ubuntu-x64.tar.gz'))
   if (asset == null) {
     throw new Error('Could not find Linux 64-bit archive in latest release')
+  }
+  return getDetailsForAsset(assets, asset)
+}
+
+function findLinux32BitRelease(assets) {
+  const asset = assets.find(a => a.name.endsWith('-ubuntu-x86.tar.gz'))
+  if (asset == null) {
+    throw new Error('Could not find Linux 32-bit archive in latest release')
+  }
+  return getDetailsForAsset(assets, asset)
+}
+
+function findLinuxARM64BitRelease(assets) {
+  const asset = assets.find(a => a.name.endsWith('-ubuntu-arm64.tar.gz'))
+  if (asset == null) {
+    throw new Error('Could not find Linux 64-bit archive in latest release')
+  }
+  return getDetailsForAsset(assets, asset)
+}
+
+function findLinuxARM32BitRelease(assets) {
+  const asset = assets.find(a => a.name.endsWith('-ubuntu-arm.tar.gz'))
+  if (asset == null) {
+    throw new Error('Could not find Linux 32-bit archive in latest release')
   }
   return getDetailsForAsset(assets, asset)
 }

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,8 +1,8 @@
 import { GitProcess, IGitResult, GitError } from '../lib'
 
 // NOTE: bump these versions to the latest stable releases
-export const gitVersion = '2.39.3'
-export const gitForWindowsVersion = '2.39.3.windows.1'
+export const gitVersion = '2.39.2'
+export const gitForWindowsVersion = '2.39.2.windows.1'
 export const gitLfsVersion = '3.3.0'
 
 const temp = require('temp').track()

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,8 +1,8 @@
 import { GitProcess, IGitResult, GitError } from '../lib'
 
 // NOTE: bump these versions to the latest stable releases
-export const gitVersion = '2.39.2'
-export const gitForWindowsVersion = '2.39.2.windows.1'
+export const gitVersion = '2.39.3'
+export const gitForWindowsVersion = '2.39.3.windows.1'
 export const gitLfsVersion = '3.3.0'
 
 const temp = require('temp').track()


### PR DESCRIPTION
Updates dugite-native to v2.39.3-1 which brings lower glibc requirements for Linux binaries, and also support for Linux arm, arm64 and x86 architectures.