### PR TITLE
Release v2.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dugite",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "Elegant bindings for Git",
   "main": "./build/lib/index.js",
   "typings": "./build/lib/index.d.ts",

--- a/script/embedded-git.json
+++ b/script/embedded-git.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/desktop/dugite-native/releases/download/v2.39.3-1/dugite-native-v2.39.3-91ebaa8-ubuntu-x64.tar.gz",
     "checksum": "78375b97c802caa33c4ab585e3cf113001f0f53d0ab623ef0086e7c5b819189d"
   },
-  "linux-x86": {
+  "linux-ia32": {
     "name": "dugite-native-v2.39.3-91ebaa8-ubuntu-x86.tar.gz",
     "url": "https://github.com/desktop/dugite-native/releases/download/v2.39.3-1/dugite-native-v2.39.3-91ebaa8-ubuntu-x86.tar.gz",
     "checksum": "1cd3511fc8a51556bdc88393cd344e0c084e7063c281137644765929ee092e8d"


### PR DESCRIPTION
- Use ia32 suffix for Linux x86 binaries #529 