### PR TITLE
Add function to parse bad config value error info

### DIFF
--- a/lib/git-process.ts
+++ b/lib/git-process.ts
@@ -291,6 +291,30 @@ export class GitProcess {
 
     return null
   }
+
+  public static parseBadConfigValueErrorInfo(
+    stderr: string
+  ): { key: string; value: string } | null {
+    const errorEntry = Object.entries(GitErrorRegexes).find(
+      ([_, v]) => v === GitError.BadConfigValue
+    )
+
+    if (errorEntry === undefined) {
+      return null
+    }
+
+    const m = stderr.match(errorEntry[0])
+
+    if (m === null) {
+      return null
+    }
+
+    if (!m[1] || !m[2]) {
+      return null
+    }
+
+    return { key: m[2], value: m[1] }
+  }
 }
 
 /**

--- a/test/fast/errors-test.ts
+++ b/test/fast/errors-test.ts
@@ -82,15 +82,10 @@ describe('detects errors', () => {
 
       expect(result).toHaveGitError(GitError.BadConfigValue)
 
-      const errorEntry = Object.entries(GitErrorRegexes).find(
-        ([_, v]) => v === GitError.BadConfigValue
-      )
-
-      expect(errorEntry).not.toBe(null)
-      const m = result.stderr.match(errorEntry![0])
-
-      expect(m![1]).toBe('nab')
-      expect(m![2]).toBe('core.autocrlf')
+      const errorInfo = GitProcess.parseBadConfigValueErrorInfo(result.stderr)
+      expect(errorInfo).not.toBe(null)
+      expect(errorInfo!.value).toBe('nab')
+      expect(errorInfo!.key).toBe('core.autocrlf')
     })
     it('detects bad numeric config value', async () => {
       const repoPath = await initialize('bad-config-repo')


### PR DESCRIPTION
As mentioned in https://github.com/desktop/desktop/pull/18292#discussion_r1521722027, the function `parseBadConfigValueErrorInfo` extracts the name of parameter and its value from git errors.

I intended to write it as an independent function, but then I noticed `parseError` was a public static function in `GitProcess` and decided to do the same.