### PR TITLE
Use dugite system config

### DIFF
--- a/lib/git-environment.ts
+++ b/lib/git-environment.ts
@@ -48,7 +48,7 @@ function resolveGitBinary(env: Record<string, string | undefined>): string {
  * then it returns with it after resolving it as a path.
  */
 function resolveGitExecPath(env: Record<string, string | undefined>): string {
-  if (env.GIT_EXEC_PATH != null) {
+  if (env.GIT_EXEC_PATH) {
     return path.resolve(env.GIT_EXEC_PATH)
   }
   const gitDir = resolveGitDir(env)

--- a/lib/git-environment.ts
+++ b/lib/git-environment.ts
@@ -21,9 +21,9 @@ function resolveEmbeddedGitDir(): string {
  *  If a custom Git directory path is defined as the `LOCAL_GIT_DIRECTORY` environment variable, then
  *  returns with it after resolving it as a path.
  */
-function resolveGitDir(): string {
-  if (process.env.LOCAL_GIT_DIRECTORY != null) {
-    return path.resolve(process.env.LOCAL_GIT_DIRECTORY)
+function resolveGitDir(env: Record<string, string | undefined>): string {
+  if (env.LOCAL_GIT_DIRECTORY != null) {
+    return path.resolve(env.LOCAL_GIT_DIRECTORY)
   } else {
     return resolveEmbeddedGitDir()
   }
@@ -32,8 +32,8 @@ function resolveGitDir(): string {
 /**
  *  Find the path to the embedded Git binary.
  */
-function resolveGitBinary(): string {
-  const gitDir = resolveGitDir()
+function resolveGitBinary(env: Record<string, string | undefined>): string {
+  const gitDir = resolveGitDir(env)
   if (process.platform === 'win32') {
     return path.join(gitDir, 'cmd', 'git.exe')
   } else {
@@ -47,11 +47,11 @@ function resolveGitBinary(): string {
  * If a custom git exec path is given as the `GIT_EXEC_PATH` environment variable,
  * then it returns with it after resolving it as a path.
  */
-function resolveGitExecPath(): string {
-  if (process.env.GIT_EXEC_PATH != null) {
-    return path.resolve(process.env.GIT_EXEC_PATH)
+function resolveGitExecPath(env: Record<string, string | undefined>): string {
+  if (env.GIT_EXEC_PATH != null) {
+    return path.resolve(env.GIT_EXEC_PATH)
   }
-  const gitDir = resolveGitDir()
+  const gitDir = resolveGitDir(env)
   if (process.platform === 'win32') {
     if (process.arch === 'x64') {
       return path.join(gitDir, 'mingw64', 'libexec', 'git-core')
@@ -71,32 +71,26 @@ function resolveGitExecPath(): string {
  *
  * @param additional options to include with the process
  */
-export function setupEnvironment(environmentVariables: NodeJS.ProcessEnv): {
-  env: NodeJS.ProcessEnv
+export function setupEnvironment(
+  environmentVariables: Record<string, string | undefined>
+): {
+  env: Record<string, string | undefined>
   gitLocation: string
 } {
-  const gitLocation = resolveGitBinary()
-
-  let envPath: string = process.env.PATH || ''
-  const gitDir = resolveGitDir()
-
-  if (process.platform === 'win32') {
-    if (process.arch === 'x64') {
-      envPath = `${gitDir}\\mingw64\\bin;${gitDir}\\mingw64\\usr\\bin;${envPath}`
-    } else {
-      envPath = `${gitDir}\\mingw32\\bin;${gitDir}\\mingw32\\usr\\bin;${envPath}`
-    }
+  const env: Record<string, string | undefined> = {
+    ...process.env,
+    ...environmentVariables,
   }
 
-  const env = Object.assign(
-    {},
-    process.env,
-    {
-      GIT_EXEC_PATH: resolveGitExecPath(),
-      PATH: envPath,
-    },
-    environmentVariables
-  )
+  const gitLocation = resolveGitBinary(env)
+  const gitDir = resolveGitDir(env)
+
+  if (process.platform === 'win32') {
+    const mingw = process.arch === 'x64' ? 'mingw64' : 'mingw32'
+    env.PATH = `${gitDir}\\${mingw}\\bin;${gitDir}\\${mingw}\\usr\\bin;${env.PATH}`
+  }
+
+  env.GIT_EXEC_PATH = resolveGitExecPath(env)
 
   if (process.platform === 'win32') {
     // while reading the environment variable is case-insensitive

--- a/lib/git-environment.ts
+++ b/lib/git-environment.ts
@@ -103,6 +103,10 @@ export function setupEnvironment(
     }
   }
 
+  if (process.platform !== 'win32' && !env.GIT_CONFIG_SYSTEM) {
+    env.GIT_CONFIG_SYSTEM = path.join(gitDir, 'etc', 'gitconfig')
+  }
+
   if (process.platform === 'darwin' || process.platform === 'linux') {
     // templates are used to populate your .git folder
     // when a repository is initialized locally

--- a/lib/git-environment.ts
+++ b/lib/git-environment.ts
@@ -103,6 +103,13 @@ export function setupEnvironment(
     }
   }
 
+  // On Windows the contained Git environment (minGit) ships with a system level
+  // gitconfig that we can control but on macOS and Linux /etc/gitconfig is used
+  // as the system-wide configuration file and we're unable to modify it.
+  //
+  // So in order to be able to provide our own sane defaults that can be overriden
+  // by the user's global and local configuration we'll tell Git to use
+  // dugite-native's custom gitconfig on those platforms.
   if (process.platform !== 'win32' && !env.GIT_CONFIG_SYSTEM) {
     env.GIT_CONFIG_SYSTEM = path.join(gitDir, 'etc', 'gitconfig')
   }

--- a/lib/git-process.ts
+++ b/lib/git-process.ts
@@ -34,7 +34,7 @@ export interface IGitSpawnExecutionOptions {
    * set as environment variables before executing the git
    * process.
    */
-  readonly env?: object
+  readonly env?: Record<string, string | undefined>
 }
 
 /**
@@ -47,7 +47,7 @@ export interface IGitExecutionOptions {
    * set as environment variables before executing the git
    * process.
    */
-  readonly env?: object
+  readonly env?: Record<string, string | undefined>
 
   /**
    * An optional string or buffer which will be written to

--- a/test/fast/errors-test.ts
+++ b/test/fast/errors-test.ts
@@ -49,7 +49,7 @@ describe('detects errors', () => {
 
     const result = await GitProcess.exec(['status'], path, {
       env: {
-        GIT_TEST_ASSUME_DIFFERENT_OWNER: 1,
+        GIT_TEST_ASSUME_DIFFERENT_OWNER: '1',
       },
     })
 

--- a/test/slow/auth.ts
+++ b/test/slow/auth.ts
@@ -14,7 +14,7 @@ function getAskPassTrampolinePath(): string {
   return Path.join(projectRoot, 'test', 'auth', `ask-pass.${extension}`)
 }
 
-const defaultEnv = {
+const defaultEnv: Record<string, string | undefined> = {
   // supported since Git 2.3, this is used to ensure we never interactively prompt
   // for credentials - even as a fallback
   GIT_TERMINAL_PROMPT: '0',
@@ -24,16 +24,19 @@ const defaultEnv = {
   HOME: '',
 }
 
-export function setupAskPass(username?: string, password?: string): object {
-  const auth = {
+export function setupAskPass(
+  username?: string,
+  password?: string
+): Record<string, string | undefined> {
+  return {
     TEST_USERNAME: username,
     TEST_PASSWORD: password,
     ASKPASS_MAIN: getAskPassScriptPath(),
     GIT_ASKPASS: getAskPassTrampolinePath(),
+    ...defaultEnv,
   }
-  return Object.assign(auth, defaultEnv)
 }
 
-export function setupNoAuth(): object {
+export function setupNoAuth() {
   return defaultEnv
 }


### PR DESCRIPTION
ref: https://github.com/desktop/dugite-native/pull/508

This will cause dugite to set the `GIT_CONFIG_SYSTEM` (unless set already) to point to the newly created system config in dugite-native. This config file will in turn include the actual system config (/etc/gitconfig).

As part of this change I've ensured that all methods that modify the env record that ends up being passed to Git operate on the provided `env` joined with `process.env`. This will allow callers to set their own `GIT_CONFIG_SYSTEM` without having to resort to modifying the current process' environment.

I've also updated the env type to be a more specific `Record` type instead of the old `object` type.

Note that we can't merge this until we've published a new version of dugite-native and incorporated it into dugite.