### PR TITLE
Update dugite-native to include GCM

### DIFF
--- a/script/embedded-git.json
+++ b/script/embedded-git.json
@@ -1,42 +1,42 @@
 {
   "win32-x64": {
-    "name": "dugite-native-v2.43.4-1074931-windows-x64.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.43.4-1/dugite-native-v2.43.4-1074931-windows-x64.tar.gz",
-    "checksum": "a1ce9ad3243a44b7b4b86056bfbc2238514faaaa8fad5da12d4483491347aace"
+    "name": "dugite-native-v2.43.4-17466a1-windows-x64.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.43.4-2/dugite-native-v2.43.4-17466a1-windows-x64.tar.gz",
+    "checksum": "0d088f671ca9515c579b66576dca96a8b5b613dfde229d352ba88af1a71d2746"
   },
   "win32-ia32": {
-    "name": "dugite-native-v2.43.4-1074931-windows-x86.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.43.4-1/dugite-native-v2.43.4-1074931-windows-x86.tar.gz",
-    "checksum": "6edd41d81bee1ad11dfa9db84bce74afafa59edd27fcd8cf836b761193a30a59"
+    "name": "dugite-native-v2.43.4-17466a1-windows-x86.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.43.4-2/dugite-native-v2.43.4-17466a1-windows-x86.tar.gz",
+    "checksum": "e3e1a48e5f82f2eeb16e5b9c36091c6bc002c8d42ed0729c9a0b3fcd9ddd5685"
   },
   "darwin-x64": {
-    "name": "dugite-native-v2.43.4-1074931-macOS-x64.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.43.4-1/dugite-native-v2.43.4-1074931-macOS-x64.tar.gz",
-    "checksum": "a7e2e4009ad119869792131b54475d3691b11a9ca2e66222be8232a9f7e323ab"
+    "name": "dugite-native-v2.43.4-17466a1-macOS-x64.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.43.4-2/dugite-native-v2.43.4-17466a1-macOS-x64.tar.gz",
+    "checksum": "3811a43962a01ba049fd9e092ec009f3097228fe81dd7f84ce6f3aa42fc458c6"
   },
   "darwin-arm64": {
-    "name": "dugite-native-v2.43.4-1074931-macOS-arm64.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.43.4-1/dugite-native-v2.43.4-1074931-macOS-arm64.tar.gz",
-    "checksum": "bc385fa42d5b01513b5c9da6ee04a4868f30b60a42bd144b5ab8b993780aef7f"
+    "name": "dugite-native-v2.43.4-17466a1-macOS-arm64.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.43.4-2/dugite-native-v2.43.4-17466a1-macOS-arm64.tar.gz",
+    "checksum": "5732de335c9c8a00d302d148ccd295711d4928a0bdd65ab4cae3afcd18301ea0"
   },
   "linux-x64": {
-    "name": "dugite-native-v2.43.4-1074931-ubuntu-x64.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.43.4-1/dugite-native-v2.43.4-1074931-ubuntu-x64.tar.gz",
-    "checksum": "fbff97763ca9cedbf87a196015f4dbffaa102681fd25103f99c40a7d561b8338"
+    "name": "dugite-native-v2.43.4-17466a1-ubuntu-x64.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.43.4-2/dugite-native-v2.43.4-17466a1-ubuntu-x64.tar.gz",
+    "checksum": "05401954be3c48b9dcd888940bc5029b190cd58d50dff2968128ba7fcace385d"
   },
   "linux-ia32": {
-    "name": "dugite-native-v2.43.4-1074931-ubuntu-x86.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.43.4-1/dugite-native-v2.43.4-1074931-ubuntu-x86.tar.gz",
-    "checksum": "458e00694dbc94a691e25c67546d93c5df58877c805d300a1d6c8ad440c56aaf"
+    "name": "dugite-native-v2.43.4-17466a1-ubuntu-x86.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.43.4-2/dugite-native-v2.43.4-17466a1-ubuntu-x86.tar.gz",
+    "checksum": "9a283c6eb83e04c2421f57671437b5eda210df615786e4a8296abf49e7426f02"
   },
   "linux-arm": {
-    "name": "dugite-native-v2.43.4-1074931-ubuntu-arm.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.43.4-1/dugite-native-v2.43.4-1074931-ubuntu-arm.tar.gz",
-    "checksum": "03e25333ce52cccf32e6b4335978f4cd53ada2ad06dd3b424132edd9f5668357"
+    "name": "dugite-native-v2.43.4-17466a1-ubuntu-arm.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.43.4-2/dugite-native-v2.43.4-17466a1-ubuntu-arm.tar.gz",
+    "checksum": "e46520db74093047ec62e969f0d92c93aa9b8239a124f5b01a2d6d9af171e589"
   },
   "linux-arm64": {
-    "name": "dugite-native-v2.43.4-1074931-ubuntu-arm64.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.43.4-1/dugite-native-v2.43.4-1074931-ubuntu-arm64.tar.gz",
-    "checksum": "1d71732200951803dd55d2b943b322d0cfab8c36a9ecd859d08f840daf95a270"
+    "name": "dugite-native-v2.43.4-17466a1-ubuntu-arm64.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.43.4-2/dugite-native-v2.43.4-17466a1-ubuntu-arm64.tar.gz",
+    "checksum": "2f02a07ae4f9458613bf110a34d50dbf8f853a2a1e0256b32ca00124a4fc8ca5"
   }
 }

--- a/script/embedded-git.json
+++ b/script/embedded-git.json
@@ -1,42 +1,42 @@
 {
   "win32-x64": {
-    "name": "dugite-native-v2.43.4-17466a1-windows-x64.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.43.4-2/dugite-native-v2.43.4-17466a1-windows-x64.tar.gz",
-    "checksum": "0d088f671ca9515c579b66576dca96a8b5b613dfde229d352ba88af1a71d2746"
+    "name": "dugite-native-v2.45.1-e87d290-windows-x64.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.45.1/dugite-native-v2.45.1-e87d290-windows-x64.tar.gz",
+    "checksum": "6a79708447291d8b95db9f523f949389d63fca1a25b72520d1a0b9a8d7ede3e1"
   },
   "win32-ia32": {
-    "name": "dugite-native-v2.43.4-17466a1-windows-x86.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.43.4-2/dugite-native-v2.43.4-17466a1-windows-x86.tar.gz",
-    "checksum": "e3e1a48e5f82f2eeb16e5b9c36091c6bc002c8d42ed0729c9a0b3fcd9ddd5685"
+    "name": "dugite-native-v2.45.1-e87d290-windows-x86.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.45.1/dugite-native-v2.45.1-e87d290-windows-x86.tar.gz",
+    "checksum": "99dafc60fdeb646988c7d6f54c74a557f877b28624ed82e4201460b7d2394d49"
   },
   "darwin-x64": {
-    "name": "dugite-native-v2.43.4-17466a1-macOS-x64.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.43.4-2/dugite-native-v2.43.4-17466a1-macOS-x64.tar.gz",
-    "checksum": "3811a43962a01ba049fd9e092ec009f3097228fe81dd7f84ce6f3aa42fc458c6"
+    "name": "dugite-native-v2.45.1-e87d290-macOS-x64.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.45.1/dugite-native-v2.45.1-e87d290-macOS-x64.tar.gz",
+    "checksum": "2a3c0b52e98a8423fe54722dd4dce905fce2d1d3014452e26df01f84c5033c3f"
   },
   "darwin-arm64": {
-    "name": "dugite-native-v2.43.4-17466a1-macOS-arm64.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.43.4-2/dugite-native-v2.43.4-17466a1-macOS-arm64.tar.gz",
-    "checksum": "5732de335c9c8a00d302d148ccd295711d4928a0bdd65ab4cae3afcd18301ea0"
+    "name": "dugite-native-v2.45.1-e87d290-macOS-arm64.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.45.1/dugite-native-v2.45.1-e87d290-macOS-arm64.tar.gz",
+    "checksum": "453ea5c74da5bb75b0474b19e0269feb548eaf2d2449b3e74a84123ced415e4c"
   },
   "linux-x64": {
-    "name": "dugite-native-v2.43.4-17466a1-ubuntu-x64.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.43.4-2/dugite-native-v2.43.4-17466a1-ubuntu-x64.tar.gz",
-    "checksum": "05401954be3c48b9dcd888940bc5029b190cd58d50dff2968128ba7fcace385d"
+    "name": "dugite-native-v2.45.1-e87d290-ubuntu-x64.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.45.1/dugite-native-v2.45.1-e87d290-ubuntu-x64.tar.gz",
+    "checksum": "cdf8c4cdca273e015d95c15fcc99e2322a97316f77f0b958b6b86424ca2b12da"
   },
   "linux-ia32": {
-    "name": "dugite-native-v2.43.4-17466a1-ubuntu-x86.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.43.4-2/dugite-native-v2.43.4-17466a1-ubuntu-x86.tar.gz",
-    "checksum": "9a283c6eb83e04c2421f57671437b5eda210df615786e4a8296abf49e7426f02"
+    "name": "dugite-native-v2.45.1-e87d290-ubuntu-x86.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.45.1/dugite-native-v2.45.1-e87d290-ubuntu-x86.tar.gz",
+    "checksum": "8ef716da12f5c2ca03288a5ee10e6cdd5ad958a164b379a6aafa19ca7f4eb72c"
   },
   "linux-arm": {
-    "name": "dugite-native-v2.43.4-17466a1-ubuntu-arm.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.43.4-2/dugite-native-v2.43.4-17466a1-ubuntu-arm.tar.gz",
-    "checksum": "e46520db74093047ec62e969f0d92c93aa9b8239a124f5b01a2d6d9af171e589"
+    "name": "dugite-native-v2.45.1-e87d290-ubuntu-arm.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.45.1/dugite-native-v2.45.1-e87d290-ubuntu-arm.tar.gz",
+    "checksum": "5b8d27f9eba833477f518377ba5339c690523cc218fb3b3189fa8cacb229493f"
   },
   "linux-arm64": {
-    "name": "dugite-native-v2.43.4-17466a1-ubuntu-arm64.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.43.4-2/dugite-native-v2.43.4-17466a1-ubuntu-arm64.tar.gz",
-    "checksum": "2f02a07ae4f9458613bf110a34d50dbf8f853a2a1e0256b32ca00124a4fc8ca5"
+    "name": "dugite-native-v2.45.1-e87d290-ubuntu-arm64.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.45.1/dugite-native-v2.45.1-e87d290-ubuntu-arm64.tar.gz",
+    "checksum": "21cec4d32ceec81efa146a40253a2f766a1d3b34a6e7c1fed1d87c7c553b3c99"
   }
 }

--- a/test/fast/gcm-test.ts
+++ b/test/fast/gcm-test.ts
@@ -8,6 +8,6 @@ describe('git-credential-manager', () => {
       process.cwd()
     )
     expect(result.exitCode).toBe(0)
-    expect(result.stdout).toContain(`git-lfs/${gitCredentialManagerVersion} `)
+    expect(result.stdout).toContain(gitCredentialManagerVersion)
   })
 })

--- a/test/fast/gcm-test.ts
+++ b/test/fast/gcm-test.ts
@@ -1,0 +1,13 @@
+import { GitProcess } from '../../lib'
+import { gitCredentialManagerVersion } from '../helpers'
+
+describe('git-credential-manager', () => {
+  it('matches the expected version', async () => {
+    const result = await GitProcess.exec(
+      ['credential-manager', '--version'],
+      process.cwd()
+    )
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain(`git-lfs/${gitCredentialManagerVersion} `)
+  })
+})

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,8 +1,8 @@
 import { GitProcess, IGitResult, GitError } from '../lib'
 
 // NOTE: bump these versions to the latest stable releases
-export const gitVersion = '2.43.4'
-export const gitForWindowsVersion = '2.43.4.windows.1'
+export const gitVersion = '2.45.1'
+export const gitForWindowsVersion = '2.45.1.windows.1'
 export const gitLfsVersion = '3.5.1'
 export const gitCredentialManagerVersion = '2.5.0'
 

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -4,6 +4,7 @@ import { GitProcess, IGitResult, GitError } from '../lib'
 export const gitVersion = '2.43.4'
 export const gitForWindowsVersion = '2.43.4.windows.1'
 export const gitLfsVersion = '3.5.1'
+export const gitCredentialManagerVersion = '2.5.0'
 
 const temp = require('temp').track()
 


### PR DESCRIPTION
See https://github.com/desktop/dugite-native/releases/tag/v2.43.4-2 and https://github.com/desktop/dugite-native/pull/510