### PR TITLE
Make sure we are copying the path variable

### DIFF
--- a/lib/git-environment.ts
+++ b/lib/git-environment.ts
@@ -83,6 +83,7 @@ export function setupEnvironment(
 } {
   const env: Record<string, string | undefined> = {
     ...process.env,
+    ...{ PATH: process.env.PATH || '' }, // Ensure PATH is always set not process.env.Path like can be on case-insensitive Windows
     ...environmentVariables,
   }
 

--- a/test/fast/environment-test.ts
+++ b/test/fast/environment-test.ts
@@ -38,6 +38,9 @@ describe('environment variables', () => {
   })
 
   it('resulting PATH contains the original PATH', async () => {
+    // This test will ensure that on platforms where env vars names are
+    // case-insensitive (like Windows) we don't end up with an invalid PATH
+    // and the original one lost in the process.
     const { env } = await setupEnvironment({})
     expect((<any>env)['PATH']).toContain(process.env.PATH)
   })

--- a/test/fast/environment-test.ts
+++ b/test/fast/environment-test.ts
@@ -36,4 +36,9 @@ describe('environment variables', () => {
       delete process.env.GIT_EXEC_PATH
     }
   })
+
+  it('resulting PATH contains the original PATH', async () => {
+    const { env } = await setupEnvironment({})
+    expect((<any>env)['PATH']).toContain(process.env.PATH)
+  })
 })


### PR DESCRIPTION
[Per some hook failures investigation](https://github.com/desktop/desktop/issues/18739#issuecomment-2148205062), we determined that the changes in https://github.com/desktop/dugite/pull/563 were causing the `PATH` environment variable to be replaced on Windows. This was causing issues with local hooks, as they rely on the `PATH` environment variable to be set correctly.

This PR ensures that the `PATH` environment variable is always set when building our env object.