### PR TITLE
Path environment variable tweaks

### DIFF
--- a/lib/git-environment.ts
+++ b/lib/git-environment.ts
@@ -92,7 +92,7 @@ export function setupEnvironment(
 
   if (process.platform === 'win32') {
     const mingw = process.arch === 'x64' ? 'mingw64' : 'mingw32'
-    env.PATH = `${gitDir}\\${mingw}\\bin;${gitDir}\\${mingw}\\usr\\bin;${env.PATH}`
+    env.PATH = `${gitDir}\\${mingw}\\bin;${gitDir}\\${mingw}\\usr\\bin;${env.PATH ?? ''}`
   }
 
   env.GIT_EXEC_PATH = resolveGitExecPath(env)

--- a/test/fast/environment-test.ts
+++ b/test/fast/environment-test.ts
@@ -37,11 +37,27 @@ describe('environment variables', () => {
     }
   })
 
-  it('resulting PATH contains the original PATH', async () => {
-    // This test will ensure that on platforms where env vars names are
-    // case-insensitive (like Windows) we don't end up with an invalid PATH
-    // and the original one lost in the process.
-    const { env } = await setupEnvironment({})
-    expect((<any>env)['PATH']).toContain(process.env.PATH)
-  })
+  if (process.platform === 'win32') {
+    it('resulting PATH contains the original PATH', () => {
+      const originalPathKey = Object.keys(process.env).find(
+        k => k.toUpperCase() === 'PATH'
+      )
+      expect(originalPathKey).not.toBeUndefined()
+
+      const originalPathValue = process.env.PATH
+
+      try {
+        delete process.env.PATH
+        process.env.Path = 'wow-such-case-insensitivity'
+        // This test will ensure that on platforms where env vars names are
+        // case-insensitive (like Windows) we don't end up with an invalid PATH
+        // and the original one lost in the process.
+        const { env } = setupEnvironment({})
+        expect(env.PATH).toContain('wow-such-case-insensitivity')
+      } finally {
+        delete process.env.Path
+        process.env[originalPathKey!] = originalPathValue
+      }
+    })
+  }
 })


### PR DESCRIPTION
@tidy-dev @sergiou87 Opening this PR with some proposed changes to #570. 

With this I've ensured that the test added by @sergiou87 fails not just on CI but on any environment regardless of their casing of the path environment variable.

Additionally I've extended the merging logic to remove any other casing of the path environment variable (not just Path) and ensure that it's always set in uppercase.

Having spent the morning thinking about this problem I do think that we should come up with a more comprehensive solution for Windows where we treat all environment variables as case-insensitive but case-preserving.