### PR TITLE
Expose string|Buffer overload

### DIFF
--- a/lib/exec.ts
+++ b/lib/exec.ts
@@ -129,6 +129,11 @@ export function exec(
   args: string[],
   path: string,
   options?: IGitExecutionOptions
+): Promise<IGitResult>
+export function exec(
+  args: string[],
+  path: string,
+  options?: IGitExecutionOptions
 ): Promise<IGitResult> {
   const { env, gitLocation } = setupEnvironment(options?.env ?? {})
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dugite",
-  "version": "3.0.0-rc3",
+  "version": "3.0.0-rc5",
   "description": "Elegant bindings for Git",
   "main": "./build/lib/index.js",
   "typings": "./build/lib/index.d.ts",


### PR DESCRIPTION
Turns out we need to double-declare the generic exec (that returns string | Buffer) in order to expose it so that Desktop can have its own generic exec.