### PR TITLE
Get rid of temp module which also depends on rimraf

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,10 +36,8 @@
   "devDependencies": {
     "@types/node": "20",
     "@types/progress": "^2.0.1",
-    "@types/temp": "^0.9.4",
     "node-test-github-reporter": "^1.2.0",
     "prettier": "^3.3.1",
-    "temp": "^0.9.4",
     "tsx": "^4.10.5",
     "typescript": "^5.4.5"
   }

--- a/test/fast/commit-test.ts
+++ b/test/fast/commit-test.ts
@@ -1,18 +1,14 @@
 import assert from 'assert'
-import { verify } from '../helpers'
+import { createTestDir, verify } from '../helpers'
 
 import * as Fs from 'fs'
 import * as Path from 'path'
-
-import { track } from 'temp'
 import { describe, it } from 'node:test'
 import { exec } from '../../lib'
 
-const temp = track()
-
 describe('commit', () => {
-  it('can commit changes', async () => {
-    const testRepoPath = temp.mkdirSync('desktop-git-test-commit')
+  it('can commit changes', async t => {
+    const testRepoPath = await createTestDir(t, 'desktop-git-test-commit')
 
     await exec(['init'], testRepoPath)
 

--- a/test/fast/environment-test.ts
+++ b/test/fast/environment-test.ts
@@ -1,14 +1,12 @@
 import assert from 'assert'
 import { setupEnvironment } from '../../lib/git-environment'
-import { track } from 'temp'
 import { describe, it } from 'node:test'
 import { exec } from '../../lib'
-
-const temp = track()
+import { createTestDir } from '../helpers'
 
 describe('environment variables', () => {
-  it('can set them', async () => {
-    const testRepoPath = temp.mkdirSync('desktop-git-test-environment')
+  it('can set them', async t => {
+    const testRepoPath = await createTestDir(t, 'desktop-git-test-environment')
     const result = await exec(['var', 'GIT_AUTHOR_IDENT'], testRepoPath, {
       env: {
         GIT_AUTHOR_NAME: 'Foo Bar',

--- a/test/fast/errors-test.ts
+++ b/test/fast/errors-test.ts
@@ -7,8 +7,8 @@ import assert from 'assert'
 import { describe, it } from 'node:test'
 
 describe('detects errors', () => {
-  it('RemoteAlreadyExists', async () => {
-    const repoPath = await initialize('remote-already-exists-test-repo')
+  it('RemoteAlreadyExists', async t => {
+    const repoPath = await initialize(t, 'remote-already-exists-test-repo')
 
     await exec(['remote', 'add', 'new-remote', 'https://github.com'], repoPath)
 
@@ -19,8 +19,8 @@ describe('detects errors', () => {
 
     assertHasGitError(result, GitError.RemoteAlreadyExists)
   })
-  it('TagAlreadyExists', async () => {
-    const repoPath = await initialize('tag-already-exists-test-repo')
+  it('TagAlreadyExists', async t => {
+    const repoPath = await initialize(t, 'tag-already-exists-test-repo')
     const filePath = 'text.md'
 
     writeFileSync(join(repoPath, filePath), 'some text')
@@ -34,17 +34,17 @@ describe('detects errors', () => {
 
     assertHasGitError(result, GitError.TagAlreadyExists)
   })
-  it('BranchAlreadyExists', async () => {
-    const path = await initialize('branch-already-exists', 'foo')
+  it('BranchAlreadyExists', async t => {
+    const path = await initialize(t, 'branch-already-exists', 'foo')
     await exec(['commit', '-m', 'initial', '--allow-empty'], path)
 
     const result = await exec(['branch', 'foo'], path)
 
     assertHasGitError(result, GitError.BranchAlreadyExists)
   })
-  it('UnsafeDirectory', async () => {
+  it('UnsafeDirectory', async t => {
     const repoName = 'branch-already-exists'
-    const path = await initialize(repoName)
+    const path = await initialize(t, repoName)
 
     const result = await exec(['status'], path, {
       env: {
@@ -65,8 +65,8 @@ describe('detects errors', () => {
     assert.ok(m![1].includes(repoName), 'repo name not found in error message')
   })
   describe('BadConfigValue', () => {
-    it('detects bad boolean config value', async () => {
-      const repoPath = await initialize('bad-config-repo')
+    it('detects bad boolean config value', async t => {
+      const repoPath = await initialize(t, 'bad-config-repo')
 
       const filePath = 'text.md'
       writeFileSync(join(repoPath, filePath), 'some text')
@@ -83,8 +83,8 @@ describe('detects errors', () => {
       assert.equal(errorInfo!.value, 'nab')
       assert.equal(errorInfo!.key, 'core.autocrlf')
     })
-    it('detects bad numeric config value', async () => {
-      const repoPath = await initialize('bad-config-repo')
+    it('detects bad numeric config value', async t => {
+      const repoPath = await initialize(t, 'bad-config-repo')
 
       const filePath = 'text.md'
       writeFileSync(join(repoPath, filePath), 'some text')

--- a/test/fast/lfs-test.ts
+++ b/test/fast/lfs-test.ts
@@ -1,14 +1,11 @@
 import assert from 'assert'
-import { gitLfsVersion } from '../helpers'
-import { track } from 'temp'
+import { createTestDir, gitLfsVersion } from '../helpers'
 import { describe, it } from 'node:test'
 import { exec } from '../../lib'
 
-const temp = track()
-
 describe('lfs', () => {
-  it('can be resolved', async () => {
-    const testRepoPath = temp.mkdirSync('desktop-git-lfs')
+  it('can be resolved', async t => {
+    const testRepoPath = await createTestDir(t, 'desktop-git-lfs')
     const result = await exec(['lfs'], testRepoPath)
     assert.equal(result.exitCode, 0)
     assert.ok(
@@ -19,8 +16,8 @@ describe('lfs', () => {
     )
   })
 
-  it('matches the expected version', async () => {
-    const testRepoPath = temp.mkdirSync('desktop-git-lfs')
+  it('matches the expected version', async t => {
+    const testRepoPath = await createTestDir(t, 'desktop-git-lfs')
     const result = await exec(['lfs', 'version'], testRepoPath)
     assert.equal(result.exitCode, 0)
     assert.ok(

--- a/test/fast/status-test.ts
+++ b/test/fast/status-test.ts
@@ -1,5 +1,4 @@
-import { verify } from '../helpers'
-import { track } from 'temp'
+import { createTestDir, verify } from '../helpers'
 
 import * as Fs from 'fs'
 import * as Path from 'path'
@@ -7,12 +6,9 @@ import assert from 'assert'
 import { describe, it } from 'node:test'
 import { exec } from '../../lib'
 
-const temp = track()
-
 describe('status', () => {
-  it('lists untracked file', async () => {
-    const testRepoPath = temp.mkdirSync('desktop-git-test-commit')
-
+  it('lists untracked file', async t => {
+    const testRepoPath = await createTestDir(t, 'desktop-git-test-commit')
     await exec(['init'], testRepoPath)
 
     const readme = Path.join(testRepoPath, 'README.md')

--- a/test/fast/stdin-test.ts
+++ b/test/fast/stdin-test.ts
@@ -1,19 +1,17 @@
 import assert from 'assert'
-import { track } from 'temp'
 import { describe, it } from 'node:test'
 import { exec } from '../../lib'
-
-const temp = track()
+import { createTestDir } from '../helpers'
 
 describe('stdin', () => {
-  it('can write large buffers', async () => {
+  it('can write large buffers', async t => {
     // Allocate 10Mb of memory
     const buffer = Buffer.alloc(1024 * 1024 * 10)
 
     // Ensure it's all filled with zeroes
     buffer.fill(0)
 
-    const testRepoPath = temp.mkdirSync('desktop-git-test-large-input')
+    const testRepoPath = await createTestDir(t, 'desktop-git-test-large-input')
 
     // Hash the object (without writing it to object database)
     const result = await exec(['hash-object', '--stdin'], testRepoPath, {
@@ -24,8 +22,8 @@ describe('stdin', () => {
     assert.equal(result.stdout, '6c5d4031e03408e34ae476c5053ee497a91ac37b\n')
   })
 
-  it('can write strings', async () => {
-    const testRepoPath = temp.mkdirSync('desktop-git-test-input-string')
+  it('can write strings', async t => {
+    const testRepoPath = await createTestDir(t, 'desktop-git-test-input-string')
 
     // Hash the object (without writing it to object database)
     const result = await exec(['hash-object', '--stdin'], testRepoPath, {
@@ -35,8 +33,8 @@ describe('stdin', () => {
     assert.equal(result.stdout, '96c906756d7b91c45322617c9295e4a80d52d1c5\n')
   })
 
-  it('can write strings with encoding', async () => {
-    const testRepoPath = temp.mkdirSync('desktop-git-test-input-string')
+  it('can write strings with encoding', async t => {
+    const testRepoPath = await createTestDir(t, 'desktop-git-test-input-string')
 
     // Hash the object (without writing it to object database)
     const result1 = await exec(['hash-object', '--stdin'], testRepoPath, {
@@ -55,8 +53,8 @@ describe('stdin', () => {
     assert.equal(result2.stdout, '652b06b434a5750d876f9eb55c07c0f1fab93464\n')
   })
 
-  it('assumes utf-8 for stdin by default', async () => {
-    const testRepoPath = temp.mkdirSync('desktop-git-test-input-string')
+  it('assumes utf-8 for stdin by default', async t => {
+    const testRepoPath = await createTestDir(t, 'desktop-git-test-input-string')
 
     // Hash the object (without writing it to object database)
     const result = await exec(['hash-object', '--stdin'], testRepoPath, {

--- a/test/slow/git-process-test.ts
+++ b/test/slow/git-process-test.ts
@@ -2,20 +2,17 @@ import * as Fs from 'fs'
 import * as Path from 'path'
 
 import { exec, GitError, parseError } from '../../lib'
-import { initialize, verify } from '../helpers'
+import { createTestDir, initialize, verify } from '../helpers'
 import { pathToFileURL } from 'url'
 import { resolve } from 'path'
 import { createServer } from 'http'
-import { track } from 'temp'
 import assert from 'assert'
 import { describe, it } from 'node:test'
 
-const temp = track()
-
 describe('git-process', () => {
   describe('clone', () => {
-    it("returns exit code when repository doesn't exist", async () => {
-      const testRepoPath = temp.mkdirSync('desktop-git-test-blank')
+    it("returns exit code when repository doesn't exist", async t => {
+      const testRepoPath = await createTestDir(t, 'desktop-git-test-blank')
 
       const result = await exec(
         [
@@ -32,8 +29,8 @@ describe('git-process', () => {
       })
     })
 
-    it('returns exit code and error when repository requires credentials', async () => {
-      const testRepoPath = temp.mkdirSync('desktop-git-test-blank')
+    it('returns exit code and error when repository requires credentials', async t => {
+      const testRepoPath = await createTestDir(t, 'desktop-git-test-blank')
       const options = {
         env: {
           GIT_CONFIG_PARAMETERS: "'credential.helper='",
@@ -80,8 +77,8 @@ describe('git-process', () => {
   })
 
   describe('fetch', () => {
-    it("returns exit code when repository doesn't exist", async () => {
-      const testRepoPath = await initialize('desktop-git-fetch-failure')
+    it("returns exit code when repository doesn't exist", async t => {
+      const testRepoPath = await initialize(t, 'desktop-git-fetch-failure')
 
       const addRemote = await exec(
         [
@@ -103,8 +100,9 @@ describe('git-process', () => {
   })
 
   describe('checkout', () => {
-    it('runs hook without error', async () => {
+    it('runs hook without error', async t => {
       const testRepoPath = await initialize(
+        t,
         'desktop-git-checkout-hooks',
         'main'
       )

--- a/test/slow/git-spawn-test.ts
+++ b/test/slow/git-spawn-test.ts
@@ -1,15 +1,11 @@
 import * as Path from 'path'
-
 import { ChildProcess } from 'child_process'
 
-import { gitForWindowsVersion, gitVersion } from '../helpers'
-import { track } from 'temp'
+import { createTestDir, gitForWindowsVersion, gitVersion } from '../helpers'
 import assert from 'assert'
 import { describe, it } from 'node:test'
 import { appendFile } from 'fs/promises'
 import { exec, spawn } from '../../lib'
-
-const temp = track()
 
 const maximumStringSize = 268435441
 
@@ -56,8 +52,8 @@ describe('spawn', () => {
     )
   })
 
-  it('returns expected exit codes', async () => {
-    const directory = temp.mkdirSync('desktop-not-a-repo')
+  it('returns expected exit codes', async t => {
+    const directory = await createTestDir(t, 'desktop-not-a-repo')
     const process = spawn(['status'], directory)
     const code = await new Promise<number | null>(resolve => {
       process.on('exit', code => {
@@ -68,8 +64,8 @@ describe('spawn', () => {
     assert.notEqual(code, 0)
   })
 
-  it('can fail safely with a diff exceeding the string length', async () => {
-    const testRepoPath = temp.mkdirSync('desktop-git-spwawn-empty')
+  it('can fail safely with a diff exceeding the string length', async t => {
+    const testRepoPath = await createTestDir(t, 'desktop-git-spwawn-empty')
 
     exec(['init'], testRepoPath)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -174,40 +174,15 @@
   dependencies:
     "@types/node" "*"
 
-"@types/temp@^0.9.4":
-  version "0.9.4"
-  resolved "https://registry.yarnpkg.com/@types/temp/-/temp-0.9.4.tgz#69bd4b0e8fc4d54db06bd1b613c19292d333350b"
-  integrity sha512-+VfWIwrlept2VBTj7Y2wQnI/Xfscy1u8Pyj/puYwss6V1IblXn1x7S0S9eFh6KyBolgLCm+rUFzhFAbdkR691g==
-  dependencies:
-    "@types/node" "*"
-
 b4a@^1.6.4:
   version "1.6.7"
   resolved "https://registry.yarnpkg.com/b4a/-/b4a-1.6.7.tgz#a99587d4ebbfbd5a6e3b21bdb5d5fa385767abe4"
   integrity sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==
 
-balanced-match@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
-  integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
-
 bare-events@^2.2.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/bare-events/-/bare-events-2.5.0.tgz#305b511e262ffd8b9d5616b056464f8e1b3329cc"
   integrity sha512-/E8dDe9dsbLyh2qrZ64PEPadOQ0F4gbl1sUJOrmph7xOiIxfY8vwab/4bFLh4Y88/Hk/ujKcrQKc+ps0mv873A==
-
-brace-expansion@^1.1.7:
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
-  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
-  dependencies:
-    balanced-match "^1.0.0"
-    concat-map "0.0.1"
-
-concat-map@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
-  integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
 error-stack-parser@^2.1.4:
   version "2.1.4"
@@ -256,11 +231,6 @@ fast-fifo@^1.2.0, fast-fifo@^1.3.2:
   resolved "https://registry.yarnpkg.com/fast-fifo/-/fast-fifo-1.3.2.tgz#286e31de96eb96d38a97899815740ba2a4f3640c"
   integrity sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==
 
-fs.realpath@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
-  integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
-
 fsevents@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
@@ -272,50 +242,6 @@ get-tsconfig@^4.7.5:
   integrity sha512-k9PN+cFBmaLWtVz29SkUoqU5O0slLuHJXt/2P+tMVFT+phsSGXGkp9t3rQIqdz0e+06EHNGs3oM6ZX1s2zHxRg==
   dependencies:
     resolve-pkg-maps "^1.0.0"
-
-glob@^7.1.3:
-  version "7.2.3"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
-  integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.1.1"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-inflight@^1.0.4:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
-  integrity sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==
-  dependencies:
-    once "^1.3.0"
-    wrappy "1"
-
-inherits@2:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
-  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
-
-minimatch@^3.1.1:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
-  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
-  dependencies:
-    brace-expansion "^1.1.7"
-
-minimist@^1.2.6:
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
-  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
-
-mkdirp@^0.5.1:
-  version "0.5.6"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
-  integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
-  dependencies:
-    minimist "^1.2.6"
 
 node-test-github-reporter@^1.2.0:
   version "1.2.0"
@@ -331,18 +257,6 @@ node-test-parser@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/node-test-parser/-/node-test-parser-2.2.2.tgz#486f0d0c08e31e6b341eadf6a9f574e8c53d8259"
   integrity sha512-Cbe0pabtJaZOrjvCguHe9kZLDrHZpRr+4+JO29hNf143qFUhGn6Xn5HxwQmh4vmyyLFlF2YmnJGIwfEX+aQ7mw==
-
-once@^1.3.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
-  integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
-  dependencies:
-    wrappy "1"
-
-path-is-absolute@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
-  integrity sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
 
 prettier@^3.3.1:
   version "3.3.3"
@@ -363,13 +277,6 @@ resolve-pkg-maps@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz#616b3dc2c57056b5588c31cdf4b3d64db133720f"
   integrity sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==
-
-rimraf@~2.6.2:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
-  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
-  dependencies:
-    glob "^7.1.3"
 
 stack-utils@^2.0.6:
   version "2.0.6"
@@ -402,14 +309,6 @@ tar-stream@^3.1.7:
     b4a "^1.6.4"
     fast-fifo "^1.2.0"
     streamx "^2.15.0"
-
-temp@^0.9.4:
-  version "0.9.4"
-  resolved "https://registry.yarnpkg.com/temp/-/temp-0.9.4.tgz#cd20a8580cb63635d0e4e9d4bd989d44286e7620"
-  integrity sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==
-  dependencies:
-    mkdirp "^0.5.1"
-    rimraf "~2.6.2"
 
 text-decoder@^1.1.0:
   version "1.2.1"
@@ -447,8 +346,3 @@ undici@^5.25.4:
   integrity sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==
   dependencies:
     "@fastify/busboy" "^2.0.0"
-
-wrappy@1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
-  integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==


### PR DESCRIPTION
Targeting #602 but extracting this to be reviewed separately to not muddy #602 any more than necessary.

So I thought we had gotten rid of rimraf in #602 but it turns out our dependency on `temp` brings it right back in. We use temp to create temporary test directories that get cleaned up after the test run. The temp module adds a hook when the process exits which cleans up all created temp directories. I took a different approach and decided to clean up after each test run instead. Felt cleaner to me to clean up resources as close to their creation as possible even though it does require passing the test context around.