### PR TITLE
Add Windows arm64 support

### DIFF
--- a/script/config.js
+++ b/script/config.js
@@ -23,12 +23,6 @@ function getConfig() {
     arch = process.env.npm_config_arch
   }
 
-  if (process.platform === 'win32' && arch === 'arm64') {
-    // Use the Dugite Native ia32 package for Windows arm64 (arm64 can run 32-bit code through emulation)
-    console.log('Downloading 32-bit Dugite Native for Windows arm64')
-    arch = 'ia32'
-  }
-
   const key = `${process.platform}-${arch}`
 
   const entry = embeddedGit[key]


### PR DESCRIPTION
Needs https://github.com/desktop/dugite-native/pull/515 to be merged first.

Now that Git for Windows supports arm64 natively, we can start using it.

Ref: https://github.com/git-for-windows/git/releases/tag/v2.47.1.windows.1
Ref: https://github.com/git-for-windows/git/issues/3107#issuecomment-2498275856