### PR TITLE
Update to git v2.47.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dugite",
-  "version": "3.0.0-rc11",
+  "version": "3.0.0-rc12",
   "description": "Elegant bindings for Git",
   "main": "./build/lib/index.js",
   "typings": "./build/lib/index.d.ts",

--- a/script/embedded-git.json
+++ b/script/embedded-git.json
@@ -1,47 +1,47 @@
 {
   "win32-x64": {
-    "name": "dugite-native-v2.47.1-8d348e6-windows-x64.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.47.1/dugite-native-v2.47.1-8d348e6-windows-x64.tar.gz",
-    "checksum": "bca0fb95b136ec4227452ee603eb5b8bf5213f9a8c99b72a617db654046c17c7"
+    "name": "dugite-native-v2.47.3-2b6f2f9-windows-x64.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.47.3/dugite-native-v2.47.3-2b6f2f9-windows-x64.tar.gz",
+    "checksum": "97b46bee58c929586349fdec6d0ee3b3378fbe8910518d6fc470d0162c91c3d7"
   },
   "win32-ia32": {
-    "name": "dugite-native-v2.47.1-8d348e6-windows-x86.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.47.1/dugite-native-v2.47.1-8d348e6-windows-x86.tar.gz",
-    "checksum": "f938bc2ef0ae702479b53bb0838b5cfeea14d35c4215757e1a6df95dea52cad4"
+    "name": "dugite-native-v2.47.3-2b6f2f9-windows-x86.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.47.3/dugite-native-v2.47.3-2b6f2f9-windows-x86.tar.gz",
+    "checksum": "38f714c4fdc7643dbee7751deab4e3ccd897d074ebb7546c0f9beca1bd091fe1"
   },
   "win32-arm64": {
-    "name": "dugite-native-v2.47.1-8d348e6-windows-arm64.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.47.1/dugite-native-v2.47.1-8d348e6-windows-arm64.tar.gz",
-    "checksum": "4a3f4d77f3fec67b1c3235a6a82c3e259eb8eb4babd868da5a3e5d5ac309c590"
+    "name": "dugite-native-v2.47.3-2b6f2f9-windows-arm64.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.47.3/dugite-native-v2.47.3-2b6f2f9-windows-arm64.tar.gz",
+    "checksum": "3ee569e91501b802a980981f61e82e17be4cbdcd0c139da4b6c2ced4bffe4435"
   },
   "darwin-x64": {
-    "name": "dugite-native-v2.47.1-8d348e6-macOS-x64.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.47.1/dugite-native-v2.47.1-8d348e6-macOS-x64.tar.gz",
-    "checksum": "475040cf643a3962d557aad9b91e861eace6d6bb28c01bb54535544c43e19459"
+    "name": "dugite-native-v2.47.3-2b6f2f9-macOS-x64.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.47.3/dugite-native-v2.47.3-2b6f2f9-macOS-x64.tar.gz",
+    "checksum": "46c592fee666d7d94e19b670d57acfcde60447f252f1faaf1cebca4ed492005b"
   },
   "darwin-arm64": {
-    "name": "dugite-native-v2.47.1-8d348e6-macOS-arm64.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.47.1/dugite-native-v2.47.1-8d348e6-macOS-arm64.tar.gz",
-    "checksum": "451dc41889a4deef06e2d3495364f74f6416bda8234b876144f5c254874b306d"
+    "name": "dugite-native-v2.47.3-2b6f2f9-macOS-arm64.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.47.3/dugite-native-v2.47.3-2b6f2f9-macOS-arm64.tar.gz",
+    "checksum": "81e1eee210760a5ca9995dbbdc55e7521673f4ba4d20af46e23679a27d827ada"
   },
   "linux-x64": {
-    "name": "dugite-native-v2.47.1-8d348e6-ubuntu-x64.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.47.1/dugite-native-v2.47.1-8d348e6-ubuntu-x64.tar.gz",
-    "checksum": "0e6b3a0776e92ddef3a3fdc966d960fbf150b3f5bb74632576c0bdfbcb638042"
+    "name": "dugite-native-v2.47.3-2b6f2f9-ubuntu-x64.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.47.3/dugite-native-v2.47.3-2b6f2f9-ubuntu-x64.tar.gz",
+    "checksum": "14bc6a09a324c03320d9655830119373ead9ae41c891a9c2a2a6d9ab18750c5b"
   },
   "linux-ia32": {
-    "name": "dugite-native-v2.47.1-8d348e6-ubuntu-x86.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.47.1/dugite-native-v2.47.1-8d348e6-ubuntu-x86.tar.gz",
-    "checksum": "7263bed583503808a11a5e3b5e259e63fe66e08d8c8c3934bef3bc6ca42f1e2e"
+    "name": "dugite-native-v2.47.3-2b6f2f9-ubuntu-x86.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.47.3/dugite-native-v2.47.3-2b6f2f9-ubuntu-x86.tar.gz",
+    "checksum": "ef1a74d2a4b626f9cd0b43daf1103a1429be39542a0c6bb0fbd26488cda0f374"
   },
   "linux-arm": {
-    "name": "dugite-native-v2.47.1-8d348e6-ubuntu-arm.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.47.1/dugite-native-v2.47.1-8d348e6-ubuntu-arm.tar.gz",
-    "checksum": "a89292d44106150037932b95ddc233e09c6faf7489b44672c93d801838f496cd"
+    "name": "dugite-native-v2.47.3-2b6f2f9-ubuntu-arm.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.47.3/dugite-native-v2.47.3-2b6f2f9-ubuntu-arm.tar.gz",
+    "checksum": "b56328beb6260af7fca61c1e286964a0943f9370a46b16c6c0c9d99e39694c30"
   },
   "linux-arm64": {
-    "name": "dugite-native-v2.47.1-8d348e6-ubuntu-arm64.tar.gz",
-    "url": "https://github.com/desktop/dugite-native/releases/download/v2.47.1/dugite-native-v2.47.1-8d348e6-ubuntu-arm64.tar.gz",
-    "checksum": "b9fcc671557a86259408b31875badaedd43408c9ef1fd4d502386d2bd36923ef"
+    "name": "dugite-native-v2.47.3-2b6f2f9-ubuntu-arm64.tar.gz",
+    "url": "https://github.com/desktop/dugite-native/releases/download/v2.47.3/dugite-native-v2.47.3-2b6f2f9-ubuntu-arm64.tar.gz",
+    "checksum": "1775b327f870851f7adc5275579cab3720c74b55b50066717a8bc70c2c6b2b4c"
   }
 }

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -6,8 +6,8 @@ import { join } from 'path'
 import { tmpdir } from 'os'
 
 // NOTE: bump these versions to the latest stable releases
-export const gitVersion = '2.47.1'
-export const gitForWindowsVersion = '2.47.1.windows.2'
+export const gitVersion = '2.47.3'
+export const gitForWindowsVersion = '2.47.3.windows.1'
 export const gitLfsVersion = '3.6.1'
 export const gitCredentialManagerVersion = '2.6.1'
 


### PR DESCRIPTION
Upgrades embedded Git binaries to v2.47.3 across all platforms and updates related version references in test helpers and package.json.